### PR TITLE
Business Contact Info unit test + Adding id to the ui elements

### DIFF
--- a/src/components/DefineCompany/BusinessContactInfo.vue
+++ b/src/components/DefineCompany/BusinessContactInfo.vue
@@ -1,16 +1,23 @@
 <template>
   <div>
     <div v-if="!isEditing">
-      <div>Email Address: {{ !!contact.email ? contact.email : 'Not entered'}}</div>
-      <div>Phone: {{ !!contact.phone ? contact.phone : 'Not entered' }}
+      <div id="lbl-email">Email Address: {{ !!contact.email ? contact.email : 'Not entered'}}</div>
+      <div id="lbl-phone">Phone: {{ !!contact.phone ? contact.phone : 'Not entered' }}
         Ext: {{ !!contact.phoneExtension ? contact.phoneExtension : 'Not entered' }}
       </div>
     </div>
     <v-card flat class="business-contact-container" v-else>
-      <v-form v-model="formValid" ref="form">
-        <v-row>
+      <v-form v-model="formValid" ref="form" name="business-contact-form">
+       <v-row>
           <v-col cols="12">
-            <v-text-field filled label="Email Address" req persistent-hint :rules="emailRules" v-model="contact.email">
+            <v-text-field
+              filled
+              label="Email Address"
+              req
+              persistent-hint
+              :rules="emailRules"
+              v-model="contact.email"
+              id="txt-email">
             </v-text-field>
           </v-col>
         </v-row>
@@ -23,7 +30,7 @@
               persistent-hint
               :error-messages="emailMustMatch()"
               v-model="contact.confirmEmail"
-            >
+              id="txt-confirm-email">
             </v-text-field>
           </v-col>
         </v-row>
@@ -38,7 +45,7 @@
               v-mask="['(###) ###-####']"
               v-model="contact.phone"
               :rules="phoneRules"
-            >
+              id="txt-phone">
             </v-text-field>
           </v-col>
           <v-col cols="3">
@@ -48,7 +55,7 @@
               persistent-hint
               v-mask="'#####'"
               v-model="contact.phoneExtension"
-            >
+              id="txt-phone-extension">
             </v-text-field>
           </v-col>
         </v-row>
@@ -125,8 +132,8 @@ export default class BusinessContactInfo extends Vue {
   @Emit('contactInfoChange')
   private emitContactInfo (contactInfo : BusinessContactIF): void { }
 
-   @Emit('contactInfoFormValidityChange')
-  private emitContactFormState (validity : boolean): void { }
+  @Emit('contactInfoFormValidityChange')
+  private emitContactFormState (validity : boolean): void {}
 }
 </script>
 

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -152,8 +152,9 @@ describe('BusinessContactInfo', () => {
   it('displays error message when user enters invalid phone number', async () => {
     const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
     const inputElement: Wrapper<Vue> = wrapper.find(phoneSelector)
-    await wrapper.vm.$nextTick()
     inputElement.setValue(invalidPhoneNumber)
+    inputElement.trigger('change')
+    await wrapper.vm.$nextTick()
     expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: email,
       confirmEmail: email,
       phone: '(11',

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -160,6 +160,7 @@ describe('BusinessContactInfo', () => {
       phone: '(11',
       phoneExtension: ''
     })
+    await wrapper.vm.$nextTick()
     expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
     expect(wrapper.find(formSelector).text()).toContain('Phone number is invalid')
     wrapper.destroy()

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -79,6 +79,7 @@ describe('BusinessContactInfo', () => {
     expect((<HTMLInputElement> wrapper.find(confirmEmailSelector).element).value).toEqual(email)
     expect((<HTMLInputElement> wrapper.find(phoneSelector).element).value).toEqual('')
     expect((<HTMLInputElement> wrapper.find(phoneExtensionSelector).element).value).toEqual('')
+    wrapper.destroy()
   })
 
   it('form is valid for correct input', async () => {
@@ -90,6 +91,7 @@ describe('BusinessContactInfo', () => {
       phone: '',
       phoneExtension: ''
     })
+    wrapper.destroy()
   })
 
   it('form is invalid for wrong email', async () => {
@@ -101,6 +103,7 @@ describe('BusinessContactInfo', () => {
       phone: '',
       phoneExtension: ''
     })
+    wrapper.destroy()
   })
 
   it('form is invalid for wrong optional phone number field', async () => {
@@ -112,6 +115,7 @@ describe('BusinessContactInfo', () => {
       phone: '(11',
       phoneExtension: ''
     })
+    wrapper.destroy()
   })
 
   it('displays error message when user enters invalid email', async () => {
@@ -127,6 +131,7 @@ describe('BusinessContactInfo', () => {
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.find(formSelector).text()).toContain('Valid email is required')
+    wrapper.destroy()
   })
 
   it('displays error message when email and confirmEmail do not match', async () => {
@@ -141,11 +146,13 @@ describe('BusinessContactInfo', () => {
       phoneExtension: ''
     })
     expect(wrapper.find(formSelector).text()).toContain('Email addresses must match')
+    wrapper.destroy()
   })
 
   it('displays error message when user enters invalid phone number', async () => {
     const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
     const inputElement: Wrapper<Vue> = wrapper.find(phoneSelector)
+    await wrapper.vm.$nextTick()
     inputElement.setValue(invalidPhoneNumber)
     await wrapper.vm.$nextTick()
     expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
@@ -155,6 +162,7 @@ describe('BusinessContactInfo', () => {
       phoneExtension: ''
     })
     expect(wrapper.find(formSelector).text()).toContain('Phone number is invalid')
+    wrapper.destroy()
   })
 
   it('displays read only data in non editing mode', async () => {
@@ -163,5 +171,6 @@ describe('BusinessContactInfo', () => {
     expect(wrapper.find(readOnlyPhoneSelector).text()).toContain('Phone: ' + phoneNumber)
     expect(wrapper.find(readOnlyPhoneSelector).text()).toContain('Ext: ' + extension)
     expect(wrapper.find(formSelector).exists()).toBeFalsy()
+    wrapper.destroy()
   })
 })

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -154,13 +154,13 @@ describe('BusinessContactInfo', () => {
     const inputElement: Wrapper<Vue> = wrapper.find(phoneSelector)
     await wrapper.vm.$nextTick()
     inputElement.setValue(invalidPhoneNumber)
-    await wrapper.vm.$nextTick()
-    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
     expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: email,
       confirmEmail: email,
       phone: '(11',
       phoneExtension: ''
     })
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
     expect(wrapper.find(formSelector).text()).toContain('Phone number is invalid')
     wrapper.destroy()
   })

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -160,7 +160,6 @@ describe('BusinessContactInfo', () => {
       phone: '(11',
       phoneExtension: ''
     })
-    await wrapper.vm.$nextTick()
     expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
     expect(wrapper.find(formSelector).text()).toContain('Phone number is invalid')
     wrapper.destroy()

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -45,8 +45,12 @@ function getLastEvent (wrapper: Wrapper<BusinessContactInfo>, name: string): any
 /**
  * Creates and mounts a component, so that it can be tested.
  *
- * @param businessContact the value to pass to the component for the name input. The default value is 'undefined'.
- * @returns a Wrapper<Certify> object with the given parameters.
+ * @param email The email address. The default value is ''.
+ * @param confirmEmail The confirm email address. The default value is ''.
+ * @param phone The phone number. The default value is ''.
+ * @param phoneExtension The phone extension. The default value is ''.
+ * @param isEditing Indicates whether the component is in editing or readonly mode. The default value is true.
+ * @returns a Wrapper<BusinessContactInfo> object with the given parameters.
  */
 function createComponent (
   email: string = '',

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -1,0 +1,162 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import { mount, Wrapper } from '@vue/test-utils'
+
+import { BusinessContactInfo } from '@/components/DefineCompany'
+import { BusinessContactIF } from '@/interfaces'
+
+Vue.use(Vuetify)
+
+let vuetify = new Vuetify({})
+
+// Events
+const formValidEvent = 'contactInfoFormValidityChange'
+const formDataChangeEvent = 'contactInfoChange'
+
+// Input field selectors to test changes to the DOM elements.
+const emailSelector: string = '#txt-email'
+const confirmEmailSelector: string = '#txt-confirm-email'
+const phoneSelector: string = '#txt-phone'
+const phoneExtensionSelector: string = '#txt-phone-extension'
+const formSelector: string = '[name="business-contact-form"]'
+const readOnlyEmailSelector: string = '#lbl-email'
+const readOnlyPhoneSelector: string = '#lbl-phone'
+
+const email: string = 'test@abc.com'
+const invalidEmail: string = 'test@'
+const phoneNumber: string = '5555555555'
+const invalidPhoneNumber: string = '11'
+const extension: string = '4444'
+
+/**
+ * Returns the last event for a given name, to be used for testing event propagation in response to component changes.
+ *
+ * @param wrapper the wrapper for the component that is being tested.
+ * @param name the name of the event that is to be returned.
+ *
+ * @returns the value of the last named event for the wrapper.
+ */
+function getLastEvent (wrapper: Wrapper<BusinessContactInfo>, name: string): any {
+  const eventsList: Array<any> = wrapper.emitted(name)
+  const events: Array<any> = eventsList[eventsList.length - 1]
+  return events[0]
+}
+
+/**
+ * Creates and mounts a component, so that it can be tested.
+ *
+ * @param businessContact the value to pass to the component for the name input. The default value is 'undefined'.
+ * @returns a Wrapper<Certify> object with the given parameters.
+ */
+function createComponent (
+  email: string = '',
+  confirmEmail: string = '',
+  phone: string = '',
+  phoneExtension: string = '',
+  isEditing: boolean = true
+): Wrapper<BusinessContactInfo> {
+  const businessContact: BusinessContactIF = {
+    email: email,
+    confirmEmail: confirmEmail,
+    phone: phone,
+    phoneExtension: phoneExtension
+  }
+  return mount(BusinessContactInfo, {
+    sync: false,
+    propsData: { initialValue: businessContact, isEditing: isEditing },
+    vuetify
+  })
+}
+
+describe('BusinessContactInfo', () => {
+  it('Loads the component and sets data for valid data', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    expect((<HTMLInputElement> wrapper.find(emailSelector).element).value).toEqual(email)
+    expect((<HTMLInputElement> wrapper.find(confirmEmailSelector).element).value).toEqual(email)
+    expect((<HTMLInputElement> wrapper.find(phoneSelector).element).value).toEqual('')
+    expect((<HTMLInputElement> wrapper.find(phoneExtensionSelector).element).value).toEqual('')
+  })
+
+  it('form is valid for correct input', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(true)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: email,
+      confirmEmail: email,
+      phone: '',
+      phoneExtension: ''
+    })
+  })
+
+  it('form is invalid for wrong email', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(invalidEmail, invalidEmail)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: invalidEmail,
+      confirmEmail: invalidEmail,
+      phone: '',
+      phoneExtension: ''
+    })
+  })
+
+  it('form is invalid for wrong optional phone number field', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email, invalidPhoneNumber)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: email,
+      confirmEmail: email,
+      phone: '(11',
+      phoneExtension: ''
+    })
+  })
+
+  it('displays error message when user enters invalid email', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    const inputElement: Wrapper<Vue> = wrapper.find(emailSelector)
+    inputElement.setValue(invalidEmail)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: invalidEmail,
+      confirmEmail: email,
+      phone: '',
+      phoneExtension: ''
+    })
+    expect(wrapper.find(formSelector).text()).toContain('Valid email is required')
+  })
+
+  it('displays error message when email and confirmEmail do not match', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    const inputElement: Wrapper<Vue> = wrapper.find(emailSelector)
+    inputElement.setValue(invalidEmail)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: invalidEmail,
+      confirmEmail: email,
+      phone: '',
+      phoneExtension: ''
+    })
+    expect(wrapper.find(formSelector).text()).toContain('Email addresses must match')
+  })
+
+  it('displays error message when user enters invalid phone number', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    const inputElement: Wrapper<Vue> = wrapper.find(phoneSelector)
+    inputElement.setValue(invalidPhoneNumber)
+    await wrapper.vm.$nextTick()
+    expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
+    expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({ email: email,
+      confirmEmail: email,
+      phone: '(11',
+      phoneExtension: ''
+    })
+    expect(wrapper.find(formSelector).text()).toContain('Phone number is invalid')
+  })
+
+  it('displays read only data in non editing mode', async () => {
+    const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email, phoneNumber, extension, false)
+    expect(wrapper.find(readOnlyEmailSelector).text()).toEqual('Email Address: ' + email)
+    expect(wrapper.find(readOnlyPhoneSelector).text()).toContain('Phone: ' + phoneNumber)
+    expect(wrapper.find(readOnlyPhoneSelector).text()).toContain('Ext: ' + extension)
+    expect(wrapper.find(formSelector).exists()).toBeFalsy()
+  })
+})

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -125,6 +125,7 @@ describe('BusinessContactInfo', () => {
       phone: '',
       phoneExtension: ''
     })
+    await wrapper.vm.$nextTick()
     expect(wrapper.find(formSelector).text()).toContain('Valid email is required')
   })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2344

*Description of changes:*
Added unit tests for Business Contact Info
Added id to the ui elements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
