### PR TITLE
#2582 Handling Saving and Fetching Draft Filings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,6 +1643,42 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^4.2.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+      "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
@@ -11237,6 +11273,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "keycloak-js": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-6.0.1.tgz",
@@ -11501,6 +11543,12 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -11592,6 +11640,15 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
       "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
       "dev": true
+    },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -12077,6 +12134,37 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "no-case": {
       "version": "2.3.2",
@@ -15185,6 +15273,38 @@
         }
       }
     },
+    "sinon": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
+      "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.2",
+        "diff": "^4.0.2",
+        "lolex": "^5.1.2",
+        "nise": "^3.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
@@ -16498,6 +16618,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -1,5 +1,5 @@
 {
-  "API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/businesses",
+  "API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "AUTH_URL": "https://dev.bcregistry.ca/cooperatives/auth/",
   "SIGNIN_URL": "https://dev.bcregistry.ca/cooperatives/auth/signin/bcsc/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1/",

--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -1,5 +1,5 @@
 {
-  "API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/businesses/",
+  "API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/businesses",
   "AUTH_URL": "https://dev.bcregistry.ca/cooperatives/auth/",
   "SIGNIN_URL": "https://dev.bcregistry.ca/cooperatives/auth/signin/bcsc/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1/",

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,6 +89,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   @Action setCurrentStep!: ActionBindingIF
   @Action setCurrentDate!: ActionBindingIF
   @Action setCertifyStatementResource!: ActionBindingIF
+  @Action setNameRequestState!: ActionBindingIF
 
   // Local Properties
   private filingData: Array<FilingDataIF> = []
@@ -97,7 +98,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
 
   private async created (): Promise<any> {
     // Mock the nrNumber and Data
-    await this.setNameRequestState({ nrNumber: 'NR7654458', entityType: 'BC', filingId: null })
+    this.setNameRequestState({ nrNumber: 'NR7654459', entityType: 'BC', filingId: null })
     this.setCurrentDate(this.dateToUsableString(new Date()))
 
     try {
@@ -105,7 +106,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
       this.draftFiling = await this.fetchDraft()
 
       // Parse the draft data into the store if it exists
-      this.draftFiling && await this.parseDraft(this.draftFiling)
+      this.draftFiling && this.parseDraft(this.draftFiling)
 
       // Inform the router view we are resuming a draft and to update ui
       this.isDraft = true

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,7 +64,7 @@ import { EntityInfo, Stepper, Actions } from '@/components/common'
 import { DateMixin, FilingTemplateMixin, LegalApiMixin } from '@/mixins'
 
 // Interfaces
-import { FilingDataIF, ActionBindingIF, StateModelIF } from '@/interfaces'
+import { FilingDataIF, ActionBindingIF, StateModelIF, IncorporationFilingIF } from '@/interfaces'
 
 import { CertifyStatementResource } from '@/resources'
 
@@ -92,19 +92,20 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
 
   // Local Properties
   private filingData: Array<FilingDataIF> = []
+  private draftFiling: IncorporationFilingIF
   private isDraft: boolean = false
 
   private async created (): Promise<any> {
     // Mock the nrNumber and Data
-    await this.setNameRequestState({ nrNumber: 'NR7654446', entityType: 'BC', filingId: null })
-
+    await this.setNameRequestState({ nrNumber: 'NR7654450', entityType: 'BC', filingId: null })
     this.setCurrentDate(this.dateToUsableString(new Date()))
+
     try {
       // Retrieve draft filing if it exists for the nrNumber specified
-      const draft = await this.fetchDraft()
+      this.draftFiling = await this.fetchDraft()
 
-      // Parse the draft data into the ui if it exists
-      draft && await this.parseDraft(draft)
+      // Parse the draft data into the store if it exists
+      this.draftFiling && await this.parseDraft(this.draftFiling)
 
       // Inform the router view we are resuming a draft and to update ui
       this.isDraft = true

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
 
   private async created (): Promise<any> {
     // Mock the nrNumber and Data
-    await this.setNameRequestState({ nrNumber: 'NR7654450', entityType: 'BC', filingId: null })
+    await this.setNameRequestState({ nrNumber: 'NR7654455', entityType: 'BC', filingId: null })
     this.setCurrentDate(this.dateToUsableString(new Date()))
 
     try {

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
 
   private async created (): Promise<any> {
     // Mock the nrNumber and Data
-    await this.setNameRequestState({ nrNumber: 'NR7654455', entityType: 'BC', filingId: null })
+    await this.setNameRequestState({ nrNumber: 'NR7654458', entityType: 'BC', filingId: null })
     this.setCurrentDate(this.dateToUsableString(new Date()))
 
     try {

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -6,7 +6,8 @@
         <v-flex md4>
           <label><strong>Mailing Address</strong></label>
           <mailing-address
-            :address="mailingAddress"
+            :key="keyTest"
+            :address="addresses.registeredOffice.mailingAddress"
             :editing="false"
             v-if="!isEmptyAddress(mailingAddress)"/>
           <div v-else>Not entered</div>
@@ -186,6 +187,7 @@ import { EntityTypes } from '@/enums'
 
 // Mixins
 import { CommonMixin, EntityFilterMixin } from '@/mixins'
+import { Getter } from 'vuex-class'
 
 @Component({
   components: {
@@ -203,11 +205,14 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   @Prop({ default: null })
   readonly inputAddresses!: IncorporationAddressIf | null;
 
-  private addresses: IncorporationAddressIf | null = this.inputAddresses;
-
   // Whether to show the editable forms for the addresses (true) or just the static display addresses (false).
   @Prop({ default: true })
   private isEditing!: boolean;
+
+  @Getter getOfficeAddresses: any
+
+  // Local Properties
+  private addresses: IncorporationAddressIf | null = this.inputAddresses;
 
   // The two addresses that are the current state of the BaseAddress components.
   private deliveryAddress = {} as AddressIF;
@@ -235,13 +240,20 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   // The Address schema containing Vuelidate rules.
   private addressSchema: {} = officeAddressSchema;
 
+  private keyTest: number = 1
+
   // Entity Enum
   readonly EntityTypes: {} = EntityTypes;
 
   /**
    * Lifecycle callback to set up the component when it is mounted.
    */
-  private mounted (): void {
+  private created (): void {
+    this.setAddresses()
+    this.emitValid()
+  }
+
+  private setAddresses (): void {
     if (this.addresses) {
       this.deliveryAddress = this.addresses.registeredOffice.deliveryAddress
       this.mailingAddress = this.addresses.registeredOffice.mailingAddress
@@ -257,11 +269,10 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
           this.isSame(this.addresses.registeredOffice.mailingAddress, this.addresses.recordsOffice!.mailingAddress)
         )
         this.inheritRecMailingAddress = this.isSame(
-          this.addresses.recordsOffice!.deliveryAddress,
-          this.addresses.recordsOffice!.mailingAddress)
+                this.addresses.recordsOffice!.deliveryAddress,
+                this.addresses.recordsOffice!.mailingAddress)
       }
     }
-    this.emitValid()
   }
 
   // Computed values.

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -6,7 +6,6 @@
         <v-flex md4>
           <label><strong>Mailing Address</strong></label>
           <mailing-address
-            :key="keyTest"
             :address="addresses.registeredOffice.mailingAddress"
             :editing="false"
             v-if="!isEmptyAddress(mailingAddress)"/>

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -187,7 +187,6 @@ import { EntityTypes } from '@/enums'
 
 // Mixins
 import { CommonMixin, EntityFilterMixin } from '@/mixins'
-import { Getter } from 'vuex-class'
 
 @Component({
   components: {
@@ -208,8 +207,6 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   // Whether to show the editable forms for the addresses (true) or just the static display addresses (false).
   @Prop({ default: true })
   private isEditing!: boolean;
-
-  @Getter getOfficeAddresses: any
 
   // Local Properties
   private addresses: IncorporationAddressIf | null = this.inputAddresses;
@@ -240,8 +237,6 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   // The Address schema containing Vuelidate rules.
   private addressSchema: {} = officeAddressSchema;
 
-  private keyTest: number = 1
-
   // Entity Enum
   readonly EntityTypes: {} = EntityTypes;
 
@@ -254,7 +249,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   }
 
   private setAddresses (): void {
-    if (this.addresses) {
+    if (this.addresses.registeredOffice) {
       this.deliveryAddress = this.addresses.registeredOffice.deliveryAddress
       this.mailingAddress = this.addresses.registeredOffice.mailingAddress
       this.inheritMailingAddress = this.isSame(

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -6,7 +6,7 @@
         <v-flex md4>
           <label><strong>Mailing Address</strong></label>
           <mailing-address
-            :address="addresses.registeredOffice.mailingAddress"
+            :address="mailingAddress"
             :editing="false"
             v-if="!isEmptyAddress(mailingAddress)"/>
           <div v-else>Not entered</div>
@@ -263,8 +263,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
           this.isSame(this.addresses.registeredOffice.mailingAddress, this.addresses.recordsOffice!.mailingAddress)
         )
         this.inheritRecMailingAddress = this.isSame(
-                this.addresses.recordsOffice!.deliveryAddress,
-                this.addresses.recordsOffice!.mailingAddress)
+          this.addresses.recordsOffice!.deliveryAddress,
+          this.addresses.recordsOffice!.mailingAddress)
       }
     }
   }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,1 +1,2 @@
 export const ADDRESSCHANGED = 'addressChanged'
+export const INCORPORATION_APPLICATION = 'incorporationApplication'

--- a/src/interfaces/filing-interfaces/filing-interface.ts
+++ b/src/interfaces/filing-interfaces/filing-interface.ts
@@ -13,7 +13,7 @@ export interface IncorporationFilingIF {
         nrNumber: string
         legalType: string
       },
-      offices: IncorporationAddressIf | null,
+      offices: IncorporationAddressIf | {},
       contactPoint: {
         email: string
         phone: string

--- a/src/interfaces/stepper-interfaces/DefineCompany/define-company-interface.ts
+++ b/src/interfaces/stepper-interfaces/DefineCompany/define-company-interface.ts
@@ -3,5 +3,5 @@ import { BusinessContactIF, NameRequestIF, IncorporationAddressIf } from '@/inte
 export interface DefineCompanyIF {
     valid: boolean
     businessContact : BusinessContactIF,
-    officeAddresses : IncorporationAddressIf | null
+    officeAddresses : IncorporationAddressIf | {}
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -60,11 +60,14 @@ export default class FilingTemplateMixin extends Vue {
    * Method to parse a received draft filing into the store
    * @param draftFiling The draft filing body to be parsed and assigned to store
    */
-  async parseDraft (draftFiling: any): Promise<any> {
+  parseDraft (draftFiling: any): void {
     try {
       // Set nameRequest data
-      this.setNameRequestState({ entityType: draftFiling.incorporationApplication.nameRequest.legalType,
-        filingId: draftFiling.header.filingId })
+      this.setNameRequestState({
+        nrNumber: draftFiling.incorporationApplication.nameRequest.nrNumber,
+        entityType: draftFiling.incorporationApplication.nameRequest.legalType,
+        filingId: draftFiling.header.filingId
+      })
 
       // Set Office Addresses
       this.setRegisteredOffice(draftFiling.incorporationApplication.offices.registeredOffice)

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -26,8 +26,6 @@ export default class FilingTemplateMixin extends Vue {
   @Action setDefineCompanyStepValidity!: ActionBindingIF
   @Action setNameRequestState!: ActionBindingIF
   @Action setFilingId!: ActionBindingIF
-  @Action setRegisteredOffice!: ActionBindingIF
-  @Action setRecordsOffice!: ActionBindingIF
 
   /**
    * Method to construct a filing body when making an api request
@@ -69,9 +67,8 @@ export default class FilingTemplateMixin extends Vue {
         filingId: draftFiling.header.filingId
       })
 
-      // Set Office Addresses
-      this.setRegisteredOffice(draftFiling.incorporationApplication.offices.registeredOffice)
-      this.setRecordsOffice(draftFiling.incorporationApplication.offices.recordsOffice)
+      // // Set Office Addresses
+      this.setOfficeAddresses(draftFiling.incorporationApplication.offices)
 
       // Set Contact Info
       this.setBusinessContact(draftFiling.incorporationApplication.contactPoint)

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -1,9 +1,12 @@
 // Libraries
 import { Component, Vue } from 'vue-property-decorator'
-import { State, Getter } from 'vuex-class'
+import { State, Getter, Action } from 'vuex-class'
 
 // Interfaces
-import { StateModelIF, IncorporationFilingIF, GetterIF } from '@/interfaces'
+import { ActionBindingIF, StateModelIF, IncorporationFilingIF, GetterIF } from '@/interfaces'
+
+// Constants
+import { INCORPORATION_APPLICATION } from '@/constants'
 
 /**
  * Mixin that provides the integration with the legal api.
@@ -16,45 +19,61 @@ export default class FilingTemplateMixin extends Vue {
   // Global Getters
   @Getter isTypeBcomp!: GetterIF
 
-  // Filing Properties
-  private name!: string
-  private certifiedBy!: string
-  private email!: string
-  private phone!: string
-  private date!: string
-  private nrNumber!: string
-  private legalType!: string
+  // Global actions
+  @Action setEntityType!: ActionBindingIF
+  @Action setBusinessContact!: ActionBindingIF
+  @Action setOfficeAddresses!: ActionBindingIF
+  @Action setDefineCompanyStepValidity!: ActionBindingIF
+  @Action setNameRequestState!: ActionBindingIF
+  @Action setFilingId!: ActionBindingIF
+  @Action setRegisteredOffice!: ActionBindingIF
+  @Action setRecordsOffice!: ActionBindingIF
 
+  /**
+   * Method to construct a filing body when making an api request
+   */
   buildFiling (): IncorporationFilingIF {
-    this.name = 'incorporationApplication'
-    this.certifiedBy = this.stateModel.certifyState.certifiedBy
-    this.email = this.stateModel.defineCompanyStep.businessContact.email
-    this.phone = this.stateModel.defineCompanyStep.businessContact.phone
-    this.date = this.stateModel.currentDate
-    this.nrNumber = this.stateModel.nameRequest.nrNumber
-    this.legalType = this.stateModel.nameRequest.entityType
-
-    const filing = {
+    return {
       filing: {
         header: {
-          name: this.name,
-          certifiedBy: this.certifiedBy,
-          email: this.email,
-          date: this.date
+          name: INCORPORATION_APPLICATION,
+          certifiedBy: this.stateModel.certifyState.certifiedBy,
+          email: this.stateModel.defineCompanyStep.businessContact.email,
+          date: this.stateModel.currentDate
         },
         incorporationApplication: {
           nameRequest: {
-            nrNumber: this.nrNumber,
-            legalType: this.legalType
+            nrNumber: this.stateModel.nameRequest.nrNumber,
+            legalType: this.stateModel.nameRequest.entityType
           },
           offices: this.stateModel.defineCompanyStep.officeAddresses,
           contactPoint: {
-            email: this.email,
-            phone: this.phone
+            email: this.stateModel.defineCompanyStep.businessContact.email,
+            phone: this.stateModel.defineCompanyStep.businessContact.phone
           }
         }
       }
     }
-    return filing
+  }
+
+  /**
+   * Method to parse a received draft filing into the store
+   * @param draftFiling The draft filing body to be parsed and assigned to store
+   */
+  async parseDraft (draftFiling: any): Promise<any> {
+    try {
+      // Set nameRequest data
+      this.setNameRequestState({ entityType: draftFiling.incorporationApplication.nameRequest.legalType,
+        filingId: draftFiling.header.filingId })
+
+      // Set Office Addresses
+      this.setRegisteredOffice(draftFiling.incorporationApplication.offices.registeredOffice)
+      this.setRecordsOffice(draftFiling.incorporationApplication.offices.recordsOffice)
+
+      // Set Contact Info
+      this.setBusinessContact(draftFiling.incorporationApplication.contactPoint)
+    } catch (e) {
+      // TODO: Throw a flag to the ui from here, if we want to trigger error handling in ui
+    }
   }
 }

--- a/src/mixins/legal-api-mixin.ts
+++ b/src/mixins/legal-api-mixin.ts
@@ -30,20 +30,12 @@ export default class LegalApiMixin extends Vue {
    */
   async saveFiling (filing: IncorporationFilingIF, isDraft: boolean): Promise<any> {
     let filingId = this.getFilingId
-
     // If have a filing id, update an existing filing
     if (filingId && filingId > 0) {
       await this.updateFiling(filing)
     } else {
       // Set the filingId to store
-      const response = await this.createFiling(filing)
-
-      // Assign a filing Id from the response to the state
-      if (response && response.header && response.header.filingId) {
-        this.setFilingId(response.header.filingId)
-      } else {
-        throw new Error('invalid API response')
-      }
+      await this.createFiling(filing)
     }
 
     // Complete a filing if not draft
@@ -53,16 +45,14 @@ export default class LegalApiMixin extends Vue {
   /**
    * Method to get a filing in progress.
    * Future: We can use this method to parse and sort the data into store.
-   * @param filingId filing id if this resuming an existing draft.
    */
-  async fetchDraft (filingId: number): Promise<any> {
+  async fetchDraft (): Promise<any> {
     try {
-      const filing = await this.getFiling(filingId)
-      // TODO: Parse the filing into store. Either here or using another method.
+      // Retrieve the Draft filingId from this identifiers tasks
+      return await this.getDraftFiling()
     } catch (e) {
-      if (e) {
-        // TODO:  Trigger some error dialog. Will catch any errors from the Api calls
-      }
+      // TODO: Throw a flag to the ui from here, if we want to trigger error handling in ui
+      throw new Error('Invalid API Response')
     }
   }
 
@@ -72,7 +62,10 @@ export default class LegalApiMixin extends Vue {
    */
   private createFiling (data: object): Promise<any> {
     return axios.post('', data).then(res => {
-      if (!res) {
+      // Assign a filing Id from the response to the state
+      if (res && res.data && res.data.filing && res.data.filing.header && res.data.filing.header.filingId) {
+        this.setFilingId(res.data.filing.header.filingId)
+      } else {
         throw new Error('invalid API response')
       }
     })
@@ -84,7 +77,7 @@ export default class LegalApiMixin extends Vue {
    */
   private updateFiling (data: object): Promise<any> {
     // Assign the url business identifier
-    let url = `${this.getBusinessIdentifier}`
+    let url = `/${this.getBusinessIdentifier}`
 
     return axios.put(url, data).then(res => {
       if (!res) {
@@ -94,15 +87,17 @@ export default class LegalApiMixin extends Vue {
   }
 
   /**
-   * Method to make a simple axios Get request.
-   * @param filingId Optional filing id if this resuming an existing draft.
+   * Method to make a simple axios Get request on the draft filings.
    */
-  private getFiling (filingId: number): Promise<any> {
+  private getDraftFiling (): Promise<any> {
     // Assign the url business identifier
-    let url = `${this.getBusinessIdentifier}/filings/${filingId}`
+    let url = `/${this.getBusinessIdentifier}/tasks`
 
     return axios.get(url).then(res => {
-      if (!res) {
+      if (res.data.tasks) {
+        this.setFilingId(res.data.tasks[0].task.filing.header.filingId)
+        return res.data.tasks[0].task.filing
+      } else {
         throw new Error('invalid API response')
       }
     })
@@ -117,7 +112,7 @@ export default class LegalApiMixin extends Vue {
 
     if (filingId) {
       // Assign the url business identifier
-      let url = `${this.getBusinessIdentifier}/filings/${filingId}`
+      let url = `/${this.getBusinessIdentifier}/filings/${filingId}`
 
       return axios.put(url, filing).then(res => {
         if (!res) {

--- a/src/mixins/legal-api-mixin.ts
+++ b/src/mixins/legal-api-mixin.ts
@@ -61,7 +61,7 @@ export default class LegalApiMixin extends Vue {
    * @param data The object body of the request.
    */
   private createFiling (data: object): Promise<any> {
-    return axios.post('', data).then(res => {
+    return axios.post('businesses', data).then(res => {
       // Assign a filing Id from the response to the state
       if (res && res.data && res.data.filing && res.data.filing.header && res.data.filing.header.filingId) {
         this.setFilingId(res.data.filing.header.filingId)
@@ -77,7 +77,7 @@ export default class LegalApiMixin extends Vue {
    */
   private updateFiling (data: object): Promise<any> {
     // Assign the url business identifier
-    let url = `/${this.getBusinessIdentifier}`
+    let url = `businesses/${this.getBusinessIdentifier}`
 
     return axios.put(url, data).then(res => {
       if (!res) {
@@ -91,7 +91,7 @@ export default class LegalApiMixin extends Vue {
    */
   private getDraftFiling (): Promise<any> {
     // Assign the url business identifier
-    let url = `/${this.getBusinessIdentifier}/tasks`
+    let url = `businesses/${this.getBusinessIdentifier}/tasks`
 
     return axios.get(url).then(res => {
       if (res.data.tasks) {
@@ -112,7 +112,7 @@ export default class LegalApiMixin extends Vue {
 
     if (filingId) {
       // Assign the url business identifier
-      let url = `/${this.getBusinessIdentifier}/filings/${filingId}`
+      let url = `businesses/${this.getBusinessIdentifier}/filings/${filingId}`
 
       return axios.put(url, filing).then(res => {
         if (!res) {

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -52,6 +52,14 @@ export const setOfficeAddresses: ActionIF = ({ commit }, address): void => {
   commit('mutateOfficeAddresses', address)
 }
 
+export const setRegisteredOffice: ActionIF = ({ commit }, address): void => {
+  commit('mutateRegisteredOffice', address)
+}
+
+export const setRecordsOffice: ActionIF = ({ commit }, address): void => {
+  commit('mutateRecordsOffice', address)
+}
+
 export const setNameRequestState: ActionIF = ({ commit }, nameRequestState): void => {
   commit('mutateNameRequestState', nameRequestState)
 }

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -52,14 +52,6 @@ export const setOfficeAddresses: ActionIF = ({ commit }, address): void => {
   commit('mutateOfficeAddresses', address)
 }
 
-export const setRegisteredOffice: ActionIF = ({ commit }, address): void => {
-  commit('mutateRegisteredOffice', address)
-}
-
-export const setRecordsOffice: ActionIF = ({ commit }, address): void => {
-  commit('mutateRecordsOffice', address)
-}
-
 export const setNameRequestState: ActionIF = ({ commit }, nameRequestState): void => {
   commit('mutateNameRequestState', nameRequestState)
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -62,6 +62,13 @@ export const getBusinessIdentifier = (state: any): string => {
 }
 
 /**
+ * Return Office addresses
+ */
+export const getOfficeAddresses = (state: any): string => {
+  return state.stateModel.defineCompanyStep.officeAddresses
+}
+
+/**
  * Whether Back button should be displayed.
  */
 export const isShowBackBtn = (state: any): boolean => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,13 +14,12 @@ import { isRoleStaff, isRoleEdit, isRoleView, isEntityType, isTypeBcomp, isTypeC
 import { mutateCurrentStep, mutateIsSaving, mutateIsSavingResuming, mutateIsFilingPaying,
   mutateResource, mutateKeycloakRoles, mutateAuthRoles, mutateCurrentDate, mutateCertifyStatementResource,
   mutateCertifyState, mutateBusinessContact, mutateDefineCompanyStepValidity, mutateNameRequestState,
-  mutateFilingId, mutateOfficeAddresses, mutateRegisteredOffice, mutateRecordsOffice } from '@/store/mutations'
+  mutateFilingId, mutateOfficeAddresses } from '@/store/mutations'
 
 // Actions
 import { setCurrentStep, setIsSaving, setIsSavingResuming, setIsFilingPaying, setResource,
   setKeycloakRoles, setAuthRoles, setCurrentDate, setCertifyStatementResource, setCertifyState, setBusinessContact,
-  setDefineCompanyStepValidity, setNameRequestState, setFilingId, setOfficeAddresses, setRegisteredOffice,
-  setRecordsOffice } from './actions'
+  setDefineCompanyStepValidity, setNameRequestState, setFilingId, setOfficeAddresses } from './actions'
 
 Vue.use(Vuex)
 
@@ -60,9 +59,7 @@ export const store: Store<any> = new Vuex.Store<any>({
     mutateDefineCompanyStepValidity,
     mutateNameRequestState,
     mutateFilingId,
-    mutateOfficeAddresses,
-    mutateRegisteredOffice,
-    mutateRecordsOffice
+    mutateOfficeAddresses
   },
   actions: {
     setCurrentStep,
@@ -79,8 +76,6 @@ export const store: Store<any> = new Vuex.Store<any>({
     setDefineCompanyStepValidity,
     setNameRequestState,
     setFilingId,
-    setOfficeAddresses,
-    setRegisteredOffice,
-    setRecordsOffice
+    setOfficeAddresses
   }
 })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,18 +8,19 @@ import { stateModel, resourceModel } from './state'
 // Getters
 import { isRoleStaff, isRoleEdit, isRoleView, isEntityType, isTypeBcomp, isTypeCoop,
   isShowBackBtn, isShowReviewConfirmBtn, isShowFilePayBtn, isEnableFilePayBtn, isBusySaving,
-  getFilingId, getBusinessIdentifier } from '@/store/getters'
+  getFilingId, getBusinessIdentifier, getOfficeAddresses } from '@/store/getters'
 
 // Mutations
 import { mutateCurrentStep, mutateIsSaving, mutateIsSavingResuming, mutateIsFilingPaying,
   mutateResource, mutateKeycloakRoles, mutateAuthRoles, mutateCurrentDate, mutateCertifyStatementResource,
   mutateCertifyState, mutateBusinessContact, mutateDefineCompanyStepValidity, mutateNameRequestState,
-  mutateFilingId, mutateOfficeAddresses } from '@/store/mutations'
+  mutateFilingId, mutateOfficeAddresses, mutateRegisteredOffice, mutateRecordsOffice } from '@/store/mutations'
 
 // Actions
 import { setCurrentStep, setIsSaving, setIsSavingResuming, setIsFilingPaying, setResource,
   setKeycloakRoles, setAuthRoles, setCurrentDate, setCertifyStatementResource, setCertifyState, setBusinessContact,
-  setDefineCompanyStepValidity, setNameRequestState, setFilingId, setOfficeAddresses } from './actions'
+  setDefineCompanyStepValidity, setNameRequestState, setFilingId, setOfficeAddresses, setRegisteredOffice,
+  setRecordsOffice } from './actions'
 
 Vue.use(Vuex)
 
@@ -41,7 +42,8 @@ export const store: Store<any> = new Vuex.Store<any>({
     isEnableFilePayBtn,
     isBusySaving,
     getFilingId,
-    getBusinessIdentifier
+    getBusinessIdentifier,
+    getOfficeAddresses
   },
   mutations: {
     mutateCurrentStep,
@@ -58,7 +60,9 @@ export const store: Store<any> = new Vuex.Store<any>({
     mutateDefineCompanyStepValidity,
     mutateNameRequestState,
     mutateFilingId,
-    mutateOfficeAddresses
+    mutateOfficeAddresses,
+    mutateRegisteredOffice,
+    mutateRecordsOffice
   },
   actions: {
     setCurrentStep,
@@ -75,6 +79,8 @@ export const store: Store<any> = new Vuex.Store<any>({
     setDefineCompanyStepValidity,
     setNameRequestState,
     setFilingId,
-    setOfficeAddresses
+    setOfficeAddresses,
+    setRegisteredOffice,
+    setRecordsOffice
   }
 })

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -1,6 +1,5 @@
-import { CertifyStatementIF, CertifyIF, IncorporationAddressIf, NameRequestIF } from '@/interfaces'
-import { ExternalResourceIF } from '@/interfaces/resource-interfaces/ExternalResourceIF'
-import { BusinessContactIF } from '@/interfaces/stepper-interfaces/DefineCompany/business-contact-interface'
+import { CertifyStatementIF, CertifyIF, IncorporationAddressIf, NameRequestIF, BaseAddressObjIF,
+  ExternalResourceIF, BusinessContactIF } from '@/interfaces'
 
 export const mutateCurrentStep = (state: any, currentStep: boolean) => {
   state.stateModel.currentStep = currentStep
@@ -50,8 +49,16 @@ export const mutateDefineCompanyStepValidity = (state: any, validity: boolean) =
   state.stateModel.defineCompanyStep.valid = validity
 }
 
-export const mutateOfficeAddresses = (state: any, address: IncorporationAddressIf) => {
-  state.stateModel.defineCompanyStep.officeAddresses = address
+export const mutateOfficeAddresses = (state: any, addresses: IncorporationAddressIf) => {
+  state.stateModel.defineCompanyStep.officeAddresses = addresses
+}
+
+export const mutateRegisteredOffice = (state: any, address: BaseAddressObjIF) => {
+  state.stateModel.defineCompanyStep.officeAddresses.registeredOffice = address
+}
+
+export const mutateRecordsOffice = (state: any, address: BaseAddressObjIF) => {
+  state.stateModel.defineCompanyStep.officeAddresses.recordsOffice = address
 }
 
 export const mutateNameRequestState = (state: any, nameRequestState: NameRequestIF) => {

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -53,14 +53,6 @@ export const mutateOfficeAddresses = (state: any, addresses: IncorporationAddres
   state.stateModel.defineCompanyStep.officeAddresses = addresses
 }
 
-export const mutateRegisteredOffice = (state: any, address: BaseAddressObjIF) => {
-  state.stateModel.defineCompanyStep.officeAddresses.registeredOffice = address
-}
-
-export const mutateRecordsOffice = (state: any, address: BaseAddressObjIF) => {
-  state.stateModel.defineCompanyStep.officeAddresses.recordsOffice = address
-}
-
 export const mutateNameRequestState = (state: any, nameRequestState: NameRequestIF) => {
   state.stateModel.nameRequest = nameRequestState
 }

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -27,6 +27,6 @@ export const stateModel: StateModelIF = {
       phone: '',
       phoneExtension: ''
     },
-    officeAddresses: null
+    officeAddresses: {}
   }
 }

--- a/src/views/DefineCompany.vue
+++ b/src/views/DefineCompany.vue
@@ -65,11 +65,11 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Vue, Mixins } from 'vue-property-decorator'
+import { Component, Mixins } from 'vue-property-decorator'
 import { Getter, Action, State } from 'vuex-class'
 
 // Interfaces
-import { GetterIF, ActionBindingIF, BusinessContactIF, IncorporationAddressIf, AddressIF } from '@/interfaces'
+import { GetterIF, ActionBindingIF, BusinessContactIF, IncorporationAddressIf } from '@/interfaces'
 
 // Mixins
 import { EntityFilterMixin } from '@/mixins'
@@ -92,7 +92,7 @@ export default class DefineCompany extends Mixins(EntityFilterMixin) {
   readonly businessContact!: BusinessContactIF
 
   @State(state => state.stateModel.defineCompanyStep.officeAddresses)
-  readonly addresses!: AddressIF
+  readonly addresses!: IncorporationAddressIf
 
   // Global getters
   @Getter isEntityType!: GetterIF

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -58,7 +58,7 @@ describe('Actions component', () => {
 describe('Actions Filing Functionality', () => {
   let wrapper: any
   const { assign } = window.location
-  sessionStorage.setItem('AUTH_URL', `myhost/basePath/auth`)
+  sessionStorage.setItem('AUTH_URL', `myhost/basePath/auth/`)
 
   const filing = {
     filing: {
@@ -195,7 +195,7 @@ describe('Actions Filing Functionality', () => {
 
     // verify redirection
     // TODO: To update when dashboard URLs are established
-    const baseUrl = 'myhost/basePath/auth'
+    const baseUrl = 'myhost/basePath/auth/'
 
     expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
   })
@@ -209,7 +209,7 @@ describe('Actions Filing Functionality', () => {
 
     // verify redirection
     // TODO: To update when dashboard URLs are established
-    const baseUrl = 'myhost/basePath/auth'
+    const baseUrl = 'myhost/basePath/auth/'
 
     expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
   })
@@ -227,7 +227,7 @@ describe('Actions Filing Functionality', () => {
 
     // verify redirection
     // TODO: To update when dashboard URLs are established
-    const baseUrl = 'myhost/basePath/auth'
+    const baseUrl = 'myhost/basePath/auth/'
 
     expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
   })

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2,8 +2,6 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
-import axios from '@/utils/axios-auth'
-import sinon from 'sinon'
 import { store } from '@/store'
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 
@@ -32,7 +30,6 @@ describe('App component', () => {
 
   afterEach(() => {
     wrapper.destroy()
-    sinon.restore()
   })
 
   it('renders the sub-components properly', () => {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2,6 +2,8 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
+import axios from '@/utils/axios-auth'
+import sinon from 'sinon'
 import { store } from '@/store'
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 
@@ -30,6 +32,7 @@ describe('App component', () => {
 
   afterEach(() => {
     wrapper.destroy()
+    sinon.restore()
   })
 
   it('renders the sub-components properly', () => {
@@ -39,5 +42,74 @@ describe('App component', () => {
     expect(wrapper.find(EntityInfo).exists()).toBe(true)
     expect(wrapper.find(Stepper).exists()).toBe(true)
     expect(wrapper.find(Actions).exists()).toBe(true)
+  })
+
+  it('loads a draft filing into store', async () => {
+    // Mock Filing response from api
+    const data = {
+      header: {
+        name: 'incorporationApplication',
+        filingId: 12345,
+        status: 'draft'
+      },
+      incorporationApplication: {
+        contactPoint: {
+          email: 'mockEmail@mock.com',
+          phone: '(250) 123-4567'
+        },
+        nameRequest: {
+          legalType: 'BC',
+          nrNumber: 'NR7654446'
+        },
+        offices: {
+          registeredOffice: {
+            deliveryAddress: {
+              streetAddress: 'delivery_address - address line one',
+              addressCity: 'delivery_address city',
+              addressCountry: 'delivery_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            },
+            mailingAddress: {
+              streetAddress: 'mailing_address - address line one',
+              addressCity: 'mailing_address city',
+              addressCountry: 'mailing_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            }
+          },
+          recordsOffice: {
+            deliveryAddress: {
+              streetAddress: 'delivery_address - address line one',
+              addressCity: 'delivery_address city',
+              addressCountry: 'delivery_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            },
+            mailingAddress: {
+              streetAddress: 'mailing_address - address line one',
+              addressCity: 'mailing_address city',
+              addressCountry: 'mailing_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            }
+          }
+        }
+      }
+    }
+    await wrapper.vm.parseDraft(data)
+
+    // Validate nrData
+    expect(store.state.stateModel.nameRequest.entityType).toBe('BC')
+    expect(store.state.stateModel.nameRequest.filingId).toBe(12345)
+
+    // Validate Office Addresses
+    expect(store.state.stateModel.defineCompanyStep.officeAddresses.registeredOffice)
+      .toBe(data.incorporationApplication.offices.registeredOffice)
+    expect(store.state.stateModel.defineCompanyStep.officeAddresses.recordsOffice)
+      .toBe(data.incorporationApplication.offices.recordsOffice)
+
+    // Validate Contact Info
+    expect(store.state.stateModel.defineCompanyStep.businessContact).toBe(data.incorporationApplication.contactPoint)
   })
 })

--- a/tests/unit/DefineCompany.spec.ts
+++ b/tests/unit/DefineCompany.spec.ts
@@ -19,7 +19,6 @@ describe('Define Company component', () => {
   let wrapper: any
 
   beforeEach(() => {
-    router.push({ name: 'define-company', query: {} })
     wrapper = shallowMount(DefineCompany, { localVue, store, router, vuetify })
   })
 

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -225,10 +225,45 @@ describe('OfficeAddresses as a BCOMP', () => {
 describe('OfficeAddresses Summary UI', () => {
   let wrapper: any
 
+  const registeredOffice = {
+    deliveryAddress: {
+      addressCity: 'someCity',
+      addressCountry: 'someCountry',
+      addressRegion: 'someRegion',
+      postalCode: 'somePostalCode',
+      streetAddress: 'someStreet'
+    },
+    mailingAddress: {
+      addressCity: 'someCity',
+      addressCountry: 'someCountry',
+      addressRegion: 'someRegion',
+      postalCode: 'somePostalCode',
+      streetAddress: 'someStreet'
+    }
+  }
+
+  const recordsOffice = {
+    deliveryAddress: {
+      addressCity: 'someRecCity',
+      addressCountry: 'someRecCountry',
+      addressRegion: 'someRecRegion',
+      postalCode: 'someRecPostalCode',
+      streetAddress: 'someRecStreet'
+    },
+    mailingAddress: {
+      addressCity: 'someRecCity',
+      addressCountry: 'someRecCountry',
+      addressRegion: 'someRecRegion',
+      postalCode: 'someRecPostalCode',
+      streetAddress: 'someRecStreet'
+    }
+  }
+
   beforeEach(() => {
     const localVue = createLocalVue()
     wrapper = shallowMount(OfficeAddresses, {
       propsData: {
+        inputAddresses: { registeredOffice, recordsOffice },
         isEditing: false
       },
       localVue,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2582

*Description of changes:*
* Updates the saving / filing incorporations filings.
* Implements a means to fetch and parse draft filings into the ui.
* Updates unit testing.

* Notes: Currently there is no dashboard to launch a draft from. This is mocked by setting a nrNumber in the App.vue ( line 100 ). If you save a filing to the specified number you will retrieve and parse the draft based off what nrNumber is set. 

* Future state: We will inject an nrNumber or other equivalent identifier into the front end from wherever we launch incorporation filings from.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
