### PR TITLE
fixed jest console errors

### DIFF
--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -129,6 +129,7 @@ describe('Actions Filing Functionality', () => {
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     wrapper = shallowMount(Actions, { localVue, store, router, vuetify })
+    jest.spyOn(wrapper.vm, 'createFiling').mockImplementation()
   })
 
   afterEach(() => {


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#2777

*Description of changes:*
- the axios call in the 'createFiling' method wasn't stubbed so it was causing the econfused error
- since these tests weren't testing the createFiling method (it was just getting called as a side effect of what was being tested) I decided to mock the createFiling method to do nothing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
