### PR TITLE
Adding the fall back key for ld client id

### DIFF
--- a/src/common/FeatureFlags.ts
+++ b/src/common/FeatureFlags.ts
@@ -44,7 +44,7 @@ class FeatureFlags {
 export const initLDClient = () : Promise<any> => {
   var user = { 'anonymous': true }
 
-  let ldClient = initialize(window['ldClientId'], user)
+  let ldClient = initialize(window['ldClientId'] || 'empty-key', user)
 
   return new Promise((resolve) => {
     ldClient.on('initialized', () => {


### PR DESCRIPTION
…n the config map

*Issue #:* /bcgov/entity#2855

*Description of changes:*
Noticed that if the ld client id is empty in the config map, the value is getting set as undefined. Specifying a fall back key will solve the issue. The fall back key can be any value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
