### PR TITLE
Incorporations draft refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7623,6 +7623,12 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+      "dev": true
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -7822,7 +7828,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7843,12 +7850,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7863,17 +7872,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7990,7 +8002,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8002,6 +8015,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8016,6 +8030,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8023,12 +8038,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8047,6 +8064,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8136,7 +8154,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8148,6 +8167,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8233,7 +8253,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8269,6 +8290,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8288,6 +8310,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8331,12 +8354,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15315,6 +15340,12 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "shvl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.0.tgz",
+      "integrity": "sha512-WbpzSvI5XgVGJ3A4ySGe8hBxj0JgJktfnoLhhJmvITDdK21WPVWwgG8GPlYEh4xqdti3Ff7PJ5G0QrRAjNS0Ig==",
+      "dev": true
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -17343,6 +17374,16 @@
       "resolved": "https://registry.npmjs.org/vuex-module-decorators/-/vuex-module-decorators-0.16.1.tgz",
       "integrity": "sha512-Zz8HF2rMoDYf78uOBbWCq8wGFFo7YyNWc10Yj2eScKxVoRMla9HnFpiqvI3Dm0cLyOnBBklCn1AFUys62BZGAw==",
       "dev": true
+    },
+    "vuex-persistedstate": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.7.1.tgz",
+      "integrity": "sha512-Ktvp6Bt6ApYj35MuxTClu+9Lpukcgl3Z/0o4PU12+Z4jU6lyOMzos0k6zGT5xrukAkGM1VV3EYNwz1TnHPhgFA==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "shvl": "^2.0.0"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git",
     "vuetify-loader": "^1.4.3",
     "vuex-class": "^0.3.2",
+    "vuex-persistedstate": "^2.7.1",
     "vuex-module-decorators": "^0.16.1"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
 
             <stepper class="mt-10" />
 
-            <router-view :key="isDraft"/>
+            <router-view />
           </v-col>
 
           <v-col cols="12" lg="3" style="position: relative">
@@ -52,7 +52,7 @@
 <script lang="ts">
 // Libraries
 import { Component, Watch, Mixins } from 'vue-property-decorator'
-import { Action, State } from 'vuex-class'
+import { Action, Getter, State } from 'vuex-class'
 
 // Components
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
@@ -64,7 +64,7 @@ import { EntityInfo, Stepper, Actions } from '@/components/common'
 import { DateMixin, FilingTemplateMixin, LegalApiMixin } from '@/mixins'
 
 // Interfaces
-import { FilingDataIF, ActionBindingIF, StateModelIF, IncorporationFilingIF } from '@/interfaces'
+import { FilingDataIF, ActionBindingIF, StateModelIF, IncorporationFilingIF, GetterIF } from '@/interfaces'
 
 import { CertifyStatementResource } from '@/resources'
 
@@ -85,6 +85,9 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   // Global state
   @State stateModel!: StateModelIF
 
+  // Getters
+  @Getter getFilingId
+
   // Global actions
   @Action setCurrentStep!: ActionBindingIF
   @Action setCurrentDate!: ActionBindingIF
@@ -94,28 +97,23 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   // Local Properties
   private filingData: Array<FilingDataIF> = []
   private draftFiling: IncorporationFilingIF
-  private isDraft: boolean = false
 
-  // TODO: Need to find a proper fix here. Currently its setting the isDraft property
-  //   on each page load, and auth does a redirect, triggering this.
-  // private async created (): Promise<any> {
-  //   // Mock the nrNumber and Data
-  //   this.setNameRequestState({ nrNumber: 'NR7654459', entityType: 'BC', filingId: null })
-  //   this.setCurrentDate(this.dateToUsableString(new Date()))
+  private async created (): Promise<any> {
+    // Mock the nrNumber and Data: UnComment to Mock a NEW NR or a return NR to save and get draft filings
+    this.setNameRequestState({ nrNumber: 'NR7654560', entityType: 'BC' })
+    this.setCurrentDate(this.dateToUsableString(new Date()))
 
-  //   try {
-  //     // Retrieve draft filing if it exists for the nrNumber specified
-  //     this.draftFiling = await this.fetchDraft()
+    try {
+      // Retrieve draft filing if it exists for the nrNumber specified
+      this.draftFiling = await this.fetchDraft()
 
-  //     // Parse the draft data into the store if it exists
-  //     this.draftFiling && this.parseDraft(this.draftFiling)
-
-  //     // Inform the router view we are resuming a draft and to update ui
-  //     this.isDraft = true
-  //   } catch (e) {
-  //     // TODO: Catch a flag from the api, if there is an error to be handled.
-  //   }
-  // }
+      // Parse the draft data into the store if it exists
+      this.draftFiling && this.parseDraft(this.draftFiling)
+    } catch (e) {
+      // TODO: Catch a flag from the api, if there is an error to be handled.
+      console.log(e)
+    }
+  }
 
   /**
    * The Pay API URL.

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@
 <script lang="ts">
 // Libraries
 import { Component, Watch, Mixins } from 'vue-property-decorator'
-import { Action, Getter, State } from 'vuex-class'
+import { Action, State } from 'vuex-class'
 
 // Components
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
@@ -64,7 +64,7 @@ import { EntityInfo, Stepper, Actions } from '@/components/common'
 import { DateMixin, FilingTemplateMixin, LegalApiMixin } from '@/mixins'
 
 // Interfaces
-import { FilingDataIF, ActionBindingIF, StateModelIF, IncorporationFilingIF, GetterIF } from '@/interfaces'
+import { FilingDataIF, ActionBindingIF, StateModelIF, IncorporationFilingIF } from '@/interfaces'
 
 import { CertifyStatementResource } from '@/resources'
 
@@ -85,9 +85,6 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   // Global state
   @State stateModel!: StateModelIF
 
-  // Getters
-  @Getter getFilingId
-
   // Global actions
   @Action setCurrentStep!: ActionBindingIF
   @Action setCurrentDate!: ActionBindingIF
@@ -99,8 +96,9 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   private draftFiling: IncorporationFilingIF
 
   private async created (): Promise<any> {
-    // Mock the nrNumber and Data: UnComment to Mock a NEW NR or a return NR to save and get draft filings
+    // Mock the nrNumber and Data:
     this.setNameRequestState({ nrNumber: 'NR7654560', entityType: 'BC' })
+
     this.setCurrentDate(this.dateToUsableString(new Date()))
 
     try {
@@ -111,7 +109,6 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
       this.draftFiling && this.parseDraft(this.draftFiling)
     } catch (e) {
       // TODO: Catch a flag from the api, if there is an error to be handled.
-      console.log(e)
     }
   }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import { routes } from './routes'
-import KeyCloakService from 'sbc-common-components/src/services/keycloak.services'
 
 // Enums for Keycloak
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,6 +1,3 @@
-// import Home from '@/views/Home.vue'
-// import MixinExample from '@/views/MixinExample.vue'
-// import StateExample from '@/views/StateExample.vue'
 import DefineCompany from '@/views/DefineCompany.vue'
 import ReviewConfirm from '@/views/ReviewConfirm.vue'
 import SigninView from '@/views/auth/Signin.vue'
@@ -9,7 +6,9 @@ import SignoutView from '@/views/auth/Signout.vue'
 export const routes = [
   {
     path: '/',
-    redirect: '/define-company'
+    meta: {
+      requiresAuth: true
+    }
   },
   {
     path: '/signin/:idpHint',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,7 @@
 // Libraries
 import Vue from 'vue'
 import Vuex, { Store } from 'vuex'
+import createPersistedState from 'vuex-persistedstate'
 
 // State
 import { stateModel, resourceModel } from './state'
@@ -24,6 +25,9 @@ import { setCurrentStep, setIsSaving, setIsSavingResuming, setIsFilingPaying, se
 Vue.use(Vuex)
 
 export const store: Store<any> = new Vuex.Store<any>({
+  plugins: [createPersistedState({
+    storage: window.sessionStorage
+  })],
   state: {
     stateModel,
     resourceModel

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -25,7 +25,7 @@ describe('App component', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
-    wrapper = shallowMount(App, { localVue, store, router, vuetify, stubs: { Affix: true } })
+    wrapper = shallowMount(App, { sync: false, localVue, store, router, vuetify, stubs: { Affix: true } })
   })
 
   afterEach(() => {

--- a/tests/unit/ReviewConfirm.spec.ts
+++ b/tests/unit/ReviewConfirm.spec.ts
@@ -38,7 +38,5 @@ describe('Review Confirm component', () => {
     expect(wrapper.find('h2').text()).toContain('Review')
   })
 
-  it('routes back to step 1 when Entity Type isn\'t set', () => {
-    expect(vm.$route.name).toBe('define-company')
-  })
+  // TODO: Expand unit testing for validation on step 5. Include routing to appropriate steps from error links.
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2958

*Description of changes:*

* Updated the filing endpoint URLS to adapt to the recent back end changes.

* Added Draft flags to filing requests where required. 

* Removed the :key from router view and now correctly allowing VUE to handle refreshing the components.

* Implemented 'vuex-persistedstate' to handle storing State in between login redirects as well as refreshing the page. One request to fetch a draft filing is made when the app loads.

* Minor unit test fixes.

* Added auth required to the root level route '/' for the redirect to pick up before redirecting to/from '/define-company'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
