### PR TITLE
2849 - update root route query param parsing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -131,7 +131,9 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
     // Check for keycloak token to see if authenticated
     // (Keycloak service does not seem to be always ready here, so we check session storage )
     // Fresh logins will initiate fetch data through the sign in component
-    // and the authenticated flag via vuex
+    // and the authenticated flag via vuex. This is required for when a user refreshes the page
+    // and they are already authenticated, so the data is refetched since the watcher for authenticated
+    // does not get re-triggered
     if (sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)) {
       this.fetchData()
     }

--- a/src/views/auth/Signin.vue
+++ b/src/views/auth/Signin.vue
@@ -41,6 +41,13 @@ export default class SigninView extends Vue {
       // Decode the redirect uri
       let redirectPath : string = decodeURIComponent(url)
       let redirectSplit: string[] = redirectPath.split('/?redirect=')
+
+      // redirect param comes in differently when accessed via the root route,
+      // if split unsuccessful
+      // check for root path expected format e.g /?nrNumber=12345
+      if (redirectSplit && redirectSplit.length === 1) {
+        redirectSplit = redirectPath.split('/')
+      }
       if (redirectSplit && redirectSplit.length >= 2 && redirectSplit[1].indexOf('?') >= 0) {
         // Split into query param strings
         let queryParams: string[] = redirectSplit[1].split('?')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2894

*Description of changes:*
Fix for when we access the root route with the nrNumber query param, it isn't properly passed through due to the redirect string format being a bit different.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
