### PR TITLE
Refactor Incorp Filing & Updated ConfirmEmail from Drafts

### DIFF
--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -154,8 +154,8 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, EntityFilter
    * @returns The appropriate Corporation or Person name.
    */
   private formatName (filing: any): string {
-    return filing?.person?.orgName ? filing?.person?.orgName
-      : `${filing.person.firstName} ${filing.person.middleName || ''} ${filing.person.lastName}`
+    return filing?.officer?.orgName ? filing?.officer?.orgName
+      : `${filing.officer.firstName} ${filing.officer.middleName || ''} ${filing.officer.lastName}`
   }
 
   /**

--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -55,13 +55,13 @@
           </v-tooltip>
         </v-col>
         <v-col>
-          <base-address class="peoples-roles-mailing-address" :address="person.address.mailingAddress" />
+          <base-address class="peoples-roles-mailing-address" :address="person.mailingAddress" />
         </v-col>
         <v-col>
-          <p v-if="isSame(person.address.mailingAddress, person.address.deliveryAddress)"
+          <p v-if="isSame(person.mailingAddress, person.deliveryAddress)"
             class="peoples-roles-delivery-address">Same as Mailing Address
           </p>
-          <base-address v-else class="peoples-roles-delivery-address" :address="person.address.deliveryAddress"/>
+          <base-address v-else class="peoples-roles-delivery-address" :address="person.deliveryAddress"/>
         </v-col>
         <v-col>
           <div v-if="person.roles.length>0">

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -32,7 +32,7 @@
                     class="item"
                     label="First Name"
                     id="person__first-name"
-                    v-model="orgPerson.person.firstName"
+                    v-model="orgPerson.officer.firstName"
                     :rules="firstNameRules"
                   />
                   <v-text-field
@@ -40,7 +40,7 @@
                     class="item"
                     label="Middle Name"
                     id="person__middle-name"
-                    v-model="orgPerson.person.middleName"
+                    v-model="orgPerson.officer.middleName"
                     :rules="middleNameRules"
                   />
                   <v-text-field
@@ -48,7 +48,7 @@
                     class="item"
                     label="Last Name"
                     id="person__last-name"
-                    v-model="orgPerson.person.lastName"
+                    v-model="orgPerson.officer.lastName"
                     :rules="lastNameRules"
                   />
                 </div>
@@ -58,7 +58,7 @@
                     class="item"
                     label="Full Legal Corporation or Firm Name"
                     id="firm-name"
-                    v-model="orgPerson.person.orgName"
+                    v-model="orgPerson.officer.orgName"
                     :rules="orgNameRules"
                   />
                 </div>
@@ -77,11 +77,11 @@
                   <v-col cols="4">
                     <div :class="{'highlightedRole':
                       isRoleLocked(Roles.INCORPORATOR) ||
-                      orgPerson.person.partyType === IncorporatorTypes.CORPORATION}">
+                      orgPerson.officer.partyType === IncorporatorTypes.CORPORATION}">
                       <v-checkbox v-model="isIncorporator"
                       :label="incorporatorLabel"
                       :disabled="isRoleLocked(Roles.INCORPORATOR) ||
-                      orgPerson.person.partyType === IncorporatorTypes.CORPORATION"
+                      orgPerson.officer.partyType === IncorporatorTypes.CORPORATION"
                       />
                     </div>
                   </v-col>
@@ -239,7 +239,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
   private created (): void {
     if (this.initialValue) {
       this.orgPerson = { ...this.initialValue }
-      this.orgPerson.person = { ...this.initialValue.person }
+      this.orgPerson.officer = { ...this.initialValue.officer }
       this.isDirector = this.orgPerson.roles.includes(Roles.DIRECTOR)
       this.isIncorporator = this.orgPerson.roles.includes(Roles.INCORPORATOR)
       this.isCompletingParty = this.orgPerson.roles.includes(Roles.COMPLETING_PARTY)
@@ -270,7 +270,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
 
   private assignCompletingPartyRole (): void {
     if (this.isCompletingParty && this.existingCompletingParty &&
-      this.orgPerson.person.id !== this.existingCompletingParty.person.id) {
+      this.orgPerson.officer.id !== this.existingCompletingParty.officer.id) {
       this.confirmReassignPerson()
     }
   }
@@ -321,9 +321,9 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
    */
   private addPerson (): OrgPersonIF {
     let personToAdd: OrgPersonIF = { ...this.orgPerson }
-    personToAdd.person = { ...this.orgPerson.person }
+    personToAdd.officer = { ...this.orgPerson.officer }
     if (this.activeIndex === -1) {
-      personToAdd.person.id = this.nextId
+      personToAdd.officer.id = this.nextId
     }
     personToAdd.mailingAddress = { ...this.inProgressMailingAddress }
     if (this.isDirector) personToAdd.deliveryAddress = this.setPersonDeliveryAddress()
@@ -373,18 +373,18 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
 
   private reassignPersonErrorMessage () : string {
     let errorMessage: string =
-    `<p>The Completing Party role is already assigned to ${this.existingCompletingParty.person.firstName}
-     ${this.existingCompletingParty.person.middleName || ''} ${this.existingCompletingParty.person.lastName}.</p>
+    `<p>The Completing Party role is already assigned to ${this.existingCompletingParty.officer.firstName}
+     ${this.existingCompletingParty.officer.middleName || ''} ${this.existingCompletingParty.officer.lastName}.</p>
      <p>Selecting "Completing Party" here will change the Completing Party.</p>`
     return errorMessage
   }
 
   get isPerson (): boolean {
-    return this.orgPerson.person?.partyType === IncorporatorTypes.PERSON
+    return this.orgPerson.officer?.partyType === IncorporatorTypes.PERSON
   }
 
   get isOrg (): boolean {
-    return this.orgPerson.person?.partyType === IncorporatorTypes.CORPORATION
+    return this.orgPerson.officer?.partyType === IncorporatorTypes.CORPORATION
   }
 
   get incorporatorLabel () : string {

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -243,9 +243,9 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
       this.isDirector = this.orgPerson.roles.includes(Roles.DIRECTOR)
       this.isIncorporator = this.orgPerson.roles.includes(Roles.INCORPORATOR)
       this.isCompletingParty = this.orgPerson.roles.includes(Roles.COMPLETING_PARTY)
-      this.inProgressMailingAddress = { ...this.orgPerson.address.mailingAddress }
+      this.inProgressMailingAddress = { ...this.orgPerson.mailingAddress }
       if (this.isDirector) {
-        this.inProgressDeliveryAddress = { ...this.orgPerson.address.deliveryAddress }
+        this.inProgressDeliveryAddress = { ...this.orgPerson.deliveryAddress }
         this.inheritMailingAddress = this.isSame(this.inProgressMailingAddress, this.inProgressDeliveryAddress)
       }
     }
@@ -325,22 +325,17 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     if (this.activeIndex === -1) {
       personToAdd.person.id = this.nextId
     }
-    personToAdd.address = this.setPersonAddress()
+    personToAdd.mailingAddress = { ...this.inProgressMailingAddress }
+    if (this.isDirector) personToAdd.deliveryAddress = this.setPersonDeliveryAddress()
     personToAdd.roles = this.setPersonRoles()
     return personToAdd
   }
 
-  private setPersonAddress (): BaseAddressObjIF {
-    let personAddress: BaseAddressObjIF = {
-      mailingAddress: { ...this.inProgressMailingAddress }
+  private setPersonDeliveryAddress (): AddressIF {
+    if (this.inheritMailingAddress) {
+      this.inProgressDeliveryAddress = this.inProgressMailingAddress
     }
-    if (this.isDirector) {
-      if (this.inheritMailingAddress) {
-        this.inProgressDeliveryAddress = this.inProgressMailingAddress
-      }
-      personAddress = { ...personAddress, deliveryAddress: { ...this.inProgressDeliveryAddress } }
-    }
-    return personAddress
+    return { ...this.inProgressDeliveryAddress }
   }
 
   private setPersonRoles (): Roles [] {

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -110,7 +110,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   @Action setAddPeopleAndRoleStepValidity!: ActionBindingIF
 
   private newOrgPerson: OrgPersonIF = {
-    person: {
+    officer: {
       id: null,
       firstName: '',
       lastName: '',
@@ -148,10 +148,10 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   private addOrgPerson (rolesToInitialize: Roles[], type: IncorporatorTypes): void {
     this.currentOrgPerson = { ...this.newOrgPerson }
     this.currentOrgPerson.roles = rolesToInitialize
-    this.currentOrgPerson.person.partyType = type
+    this.currentOrgPerson.officer.partyType = type
     this.activeIndex = -1
     this.nextId = (this.orgPersonList.length === 0)
-      ? 0 : this.orgPersonList[this.orgPersonList.length - 1].person.id + 1
+      ? 0 : this.orgPersonList[this.orgPersonList.length - 1].officer.id + 1
     this.addEditInProgress = true
     this.showOrgPersonForm = true
   }

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -119,16 +119,14 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
       partyType: null
     },
     roles: [],
-    address: {
-      mailingAddress: {
-        streetAddress: '',
-        streetAddressAdditional: '',
-        addressCity: '',
-        addressRegion: '',
-        postalCode: '',
-        addressCountry: '',
-        deliveryInstructions: ''
-      }
+    mailingAddress: {
+      streetAddress: '',
+      streetAddressAdditional: '',
+      addressCity: '',
+      addressRegion: '',
+      postalCode: '',
+      addressCountry: '',
+      deliveryInstructions: ''
     }
   }
 

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -501,7 +501,7 @@ label:first-child {
 }
 .records-inherit-checkbox {
   margin-top: 0rem;
-  margin-left: 4.65rem;
+  margin-left: 4.5rem;
   margin-bottom: -1.5rem;
   padding: 0;
 

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
@@ -2,7 +2,7 @@ import { AddressIF } from '@/interfaces'
 import { Roles, IncorporatorTypes } from '@/enums'
 
 export interface OrgPersonIF {
-  person: {
+  officer: {
     id: number | null
     partyType: IncorporatorTypes;
     firstName: string;

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
@@ -1,4 +1,4 @@
-import { BaseAddressObjIF } from '@/interfaces'
+import { AddressIF } from '@/interfaces'
 import { Roles, IncorporatorTypes } from '@/enums'
 
 export interface OrgPersonIF {
@@ -11,5 +11,6 @@ export interface OrgPersonIF {
     orgName: string
   },
   roles: Roles[];
-  address: BaseAddressObjIF;
+  mailingAddress: AddressIF;
+  deliveryAddress?: AddressIF;
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -73,7 +73,11 @@ export default class FilingTemplateMixin extends Vue {
       this.setOfficeAddresses(draftFiling.incorporationApplication.offices)
 
       // Set Contact Info
-      this.setBusinessContact(draftFiling.incorporationApplication.contactPoint)
+      const draftContact = {
+        ...draftFiling.incorporationApplication.contactPoint,
+        confirmEmail: draftFiling.incorporationApplication.contactPoint.email
+      }
+      this.setBusinessContact(draftContact)
 
       // Set Persons and Organizations
       this.setOrgPersonList(draftFiling.incorporationApplication.parties)

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -52,6 +52,7 @@ describe('App component', () => {
       incorporationApplication: {
         contactPoint: {
           email: 'mockEmail@mock.com',
+          confirmEmail: 'mockEmail@mock.com',
           phone: '(250) 123-4567'
         },
         nameRequest: {
@@ -102,11 +103,11 @@ describe('App component', () => {
 
     // Validate Office Addresses
     expect(store.state.stateModel.defineCompanyStep.officeAddresses.registeredOffice)
-      .toBe(data.incorporationApplication.offices.registeredOffice)
+      .toStrictEqual(data.incorporationApplication.offices.registeredOffice)
     expect(store.state.stateModel.defineCompanyStep.officeAddresses.recordsOffice)
-      .toBe(data.incorporationApplication.offices.recordsOffice)
+      .toStrictEqual(data.incorporationApplication.offices.recordsOffice)
 
     // Validate Contact Info
-    expect(store.state.stateModel.defineCompanyStep.businessContact).toBe(data.incorporationApplication.contactPoint)
+    expect(store.state.stateModel.defineCompanyStep.businessContact).toStrictEqual(data.incorporationApplication.contactPoint)
   })
 })

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -24,7 +24,7 @@ describe('List People And Roles', () => {
 
   const mockPersonList = [
     {
-      'person': {
+      'officer': {
         'id': 0,
         'firstName': 'Cameron',
         'lastName': 'Bowler',
@@ -54,7 +54,7 @@ describe('List People And Roles', () => {
       }
     },
     {
-      'person': {
+      'officer': {
         'id': 1,
         'firstName': '',
         'lastName': '',

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -36,23 +36,21 @@ describe('List People And Roles', () => {
         'Completing Party',
         'Director'
       ],
-      'address': {
-        'mailingAddress': {
-          'streetAddress': '122-12210 Boul De Pierrefonds',
-          'streetAddressAdditional': '',
-          'addressCity': 'Pierrefonds',
-          'addressRegion': 'QC',
-          'postalCode': 'H9A 2X6',
-          'addressCountry': 'CA'
-        },
-        'deliveryAddress': {
-          'streetAddress': '122-12210 Boul De Pierrefonds',
-          'streetAddressAdditional': '',
-          'addressCity': 'Pierrefonds',
-          'addressRegion': 'QC',
-          'postalCode': 'H9A 2X6',
-          'addressCountry': 'CA'
-        }
+      'mailingAddress': {
+        'streetAddress': '122-12210 Boul De Pierrefonds',
+        'streetAddressAdditional': '',
+        'addressCity': 'Pierrefonds',
+        'addressRegion': 'QC',
+        'postalCode': 'H9A 2X6',
+        'addressCountry': 'CA'
+      },
+      'deliveryAddress': {
+        'streetAddress': '122-12210 Boul De Pierrefonds',
+        'streetAddressAdditional': '',
+        'addressCity': 'Pierrefonds',
+        'addressRegion': 'QC',
+        'postalCode': 'H9A 2X6',
+        'addressCountry': 'CA'
       }
     },
     {
@@ -67,15 +65,13 @@ describe('List People And Roles', () => {
       'roles': [
         'Incorporator'
       ],
-      'address': {
-        'mailingAddress': {
-          'streetAddress': '12-1044 Boul 21De Normandie',
-          'streetAddressAdditional': '',
-          'addressCity': 'Saint-Jean-Sur-Richelieu',
-          'addressRegion': 'QC',
-          'postalCode': 'J3A 1H7',
-          'addressCountry': 'CA'
-        }
+      'mailingAddress': {
+        'streetAddress': '12-1044 Boul 21De Normandie',
+        'streetAddressAdditional': '',
+        'addressCity': 'Saint-Jean-Sur-Richelieu',
+        'addressRegion': 'QC',
+        'postalCode': 'J3A 1H7',
+        'addressCountry': 'CA'
       }
     }
   ]
@@ -156,7 +152,7 @@ describe('List People And Roles', () => {
   })
 
   it('displays the correct addresses text when mailing and delivery do NOT match', () => {
-    mockPersonList[0].address.deliveryAddress.streetAddress = '123 Different rd'
+    mockPersonList[0].deliveryAddress.streetAddress = '123 Different rd'
     // Mounting the Wrapper to allow for the test to reach into the baseAddress component to validate data
     const wrapper = mount(ListPeopleAndRoles, { propsData: { personList: mockPersonList }, vuetify })
 

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -32,7 +32,7 @@ const cancelButtonSelector: string = '#btn-cancel'
 const formSelector: string = '.appoint-form'
 
 const validPersonData = {
-  'person': {
+  'officer': {
     'id': 0,
     'firstName': 'Adam',
     'lastName': 'Smith',
@@ -60,7 +60,7 @@ const validPersonData = {
 }
 
 const validIncorporator = {
-  'person': {
+  'officer': {
     'id': 1,
     'firstName': 'Adam',
     'lastName': 'Smith',
@@ -88,7 +88,7 @@ const validIncorporator = {
 }
 
 const validOrgData = {
-  'person': {
+  'officer': {
     'id': 0,
     'firstName': '',
     'lastName': '',
@@ -174,7 +174,7 @@ describe('OrgPerson', () => {
   it('Displays form data for org', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validOrgData, -1, 0, null)
     expect((<HTMLInputElement> wrapper.find(orgNameSelector).element).value)
-      .toEqual(validOrgData['person']['orgName'])
+      .toEqual(validOrgData['officer']['orgName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeDefined()
@@ -185,11 +185,11 @@ describe('OrgPerson', () => {
   it('Displays form data for person', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validPersonData, 0, 0, null)
     expect((<HTMLInputElement> wrapper.find(firstNameSelector).element).value)
-      .toEqual(validPersonData['person']['firstName'])
+      .toEqual(validPersonData['officer']['firstName'])
     expect((<HTMLInputElement> wrapper.find(middleNameSelector).element).value)
-      .toEqual(validPersonData['person']['middleName'])
+      .toEqual(validPersonData['officer']['middleName'])
     expect((<HTMLInputElement> wrapper.find(lastNameSelector).element).value)
-      .toEqual(validPersonData['person']['lastName'])
+      .toEqual(validPersonData['officer']['lastName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeUndefined()
@@ -220,7 +220,7 @@ describe('OrgPerson', () => {
   it('Clicking Done button emits event for add edit person/org', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validOrgData, -1, 0, null)
     expect((<HTMLInputElement> wrapper.find(orgNameSelector).element).value)
-      .toEqual(validOrgData['person']['orgName'])
+      .toEqual(validOrgData['officer']['orgName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     wrapper.find(doneButtonSelector).trigger('click')

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -41,23 +41,21 @@ const validPersonData = {
     'partyType': 'Person'
   },
   'roles': ['Director', 'Completing Party'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    },
-    'deliveryAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
+  },
+  'deliveryAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -71,23 +69,21 @@ const validIncorporator = {
     'partyType': 'Person'
   },
   'roles': ['Incorporator'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    },
-    'deliveryAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
+  },
+  'deliveryAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -101,15 +97,13 @@ const validOrgData = {
     'partyType': 'Org'
   },
   'roles': ['Incorporator'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '3942 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '3942 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -294,7 +288,6 @@ describe('OrgPerson', () => {
     expect(wrapper.emitted(addEditPersonEvent).length).toBe(1)
     let incorporatorWithAddedRole = { ...validIncorporator }
     incorporatorWithAddedRole.roles = ['Completing Party', 'Incorporator']
-    delete incorporatorWithAddedRole.address.deliveryAddress
 
     expect(wrapper.emitted(addEditPersonEvent)[0][0]).toStrictEqual(incorporatorWithAddedRole)
 

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -40,7 +40,7 @@ function resetStore (): void {
 function getPersonList (roles: string[] = [completingPartyRole]) : any {
   const mockPersonList = [
     {
-      'person': {
+      'officer': {
         'id': 0,
         'firstName': 'Adam',
         'lastName': 'Smith',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3134

*Description of changes:*

* Removed the `Address` wrapping in the incorporations filings to match schema.
* Implemented a means of restoring the confirmEmail property when resuming a draft for better UX.
* Updated minor styling to align checkboxes.
* Updated Unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
