### PR TITLE
Business-Create Refactor to Sync to Schema Changes.

### DIFF
--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -80,7 +80,7 @@
           <div class="actions">
             <span class="edit-action">
               <v-btn small text color="primary"
-                :id="'person-' + officer.id + '-change-btn'"
+                :id="'officer-' + officer.id + '-change-btn'"
                 @click="emitPersonInfo(index)"
               >
                 <v-icon small>mdi-pencil</v-icon>

--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -154,8 +154,8 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, EntityFilter
    * @returns The appropriate Corporation or Person name.
    */
   private formatName (filing: any): string {
-    return filing?.person?.orgName ? filing?.person?.orgName
-      : `${filing.person.firstName} ${filing.person.middleName || ''} ${filing.person.lastName}`
+    return filing?.officer?.orgName ? filing?.officer?.orgName
+      : `${filing.officer.firstName} ${filing.officer.middleName || ''} ${filing.officer.lastName}`
   }
 
   /**

--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -55,13 +55,13 @@
           </v-tooltip>
         </v-col>
         <v-col>
-          <base-address class="peoples-roles-mailing-address" :address="person.address.mailingAddress" />
+          <base-address class="peoples-roles-mailing-address" :address="person.mailingAddress" />
         </v-col>
         <v-col>
-          <p v-if="isSame(person.address.mailingAddress, person.address.deliveryAddress)"
+          <p v-if="isSame(person.mailingAddress, person.deliveryAddress)"
             class="peoples-roles-delivery-address">Same as Mailing Address
           </p>
-          <base-address v-else class="peoples-roles-delivery-address" :address="person.address.deliveryAddress"/>
+          <base-address v-else class="peoples-roles-delivery-address" :address="person.deliveryAddress"/>
         </v-col>
         <v-col>
           <div v-if="person.roles.length>0">

--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -43,30 +43,30 @@
       <v-row
         class="people-roles-content"
         :class="{ 'list-item__subtitle': !isSummary }"
-        v-for="(person, index) in personList"
+        v-for="(officer, index) in personList"
         :key="index"
         no-gutters>
         <v-col class="text-truncate">
-          <v-tooltip top :disabled="formatName(person).length < 25" color="primary">
+          <v-tooltip top :disabled="formatName(officer).length < 25" color="primary">
             <template v-slot:activator="{ on }">
-              <span v-on="on" class="people-roles-title"><strong>{{formatName(person)}}</strong></span>
+              <span v-on="on" class="people-roles-title"><strong>{{formatName(officer)}}</strong></span>
             </template>
-            <span>{{formatName(person)}}</span>
+            <span>{{formatName(officer)}}</span>
           </v-tooltip>
         </v-col>
         <v-col>
-          <base-address class="peoples-roles-mailing-address" :address="person.mailingAddress" />
+          <base-address class="peoples-roles-mailing-address" :address="officer.mailingAddress" />
         </v-col>
         <v-col>
-          <p v-if="isSame(person.mailingAddress, person.deliveryAddress)"
+          <p v-if="isSame(officer.mailingAddress, officer.deliveryAddress)"
             class="peoples-roles-delivery-address">Same as Mailing Address
           </p>
-          <base-address v-else class="peoples-roles-delivery-address" :address="person.deliveryAddress"/>
+          <base-address v-else class="peoples-roles-delivery-address" :address="officer.deliveryAddress"/>
         </v-col>
         <v-col>
-          <div v-if="person.roles.length>0">
-            <v-col v-for="(role, index) in person.roles" :key="index" class="col-roles">
-              <span>{{role}}</span>
+          <div v-if="officer.roles.length>0">
+            <v-col v-for="(role, index) in officer.roles" :key="index" class="col-roles">
+              <span>{{role.roleType}}</span>
             </v-col>
           </div>
           <div v-else>
@@ -80,7 +80,7 @@
           <div class="actions">
             <span class="edit-action">
               <v-btn small text color="primary"
-                :id="'person-' + person.id + '-change-btn'"
+                :id="'person-' + officer.id + '-change-btn'"
                 @click="emitPersonInfo(index)"
               >
                 <v-icon small>mdi-pencil</v-icon>

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -32,7 +32,7 @@
                     class="item"
                     label="First Name"
                     id="person__first-name"
-                    v-model="orgPerson.person.firstName"
+                    v-model="orgPerson.officer.firstName"
                     :rules="firstNameRules"
                   />
                   <v-text-field
@@ -40,7 +40,7 @@
                     class="item"
                     label="Middle Name"
                     id="person__middle-name"
-                    v-model="orgPerson.person.middleName"
+                    v-model="orgPerson.officer.middleName"
                     :rules="middleNameRules"
                   />
                   <v-text-field
@@ -48,7 +48,7 @@
                     class="item"
                     label="Last Name"
                     id="person__last-name"
-                    v-model="orgPerson.person.lastName"
+                    v-model="orgPerson.officer.lastName"
                     :rules="lastNameRules"
                   />
                 </div>
@@ -58,7 +58,7 @@
                     class="item"
                     label="Full Legal Corporation or Firm Name"
                     id="firm-name"
-                    v-model="orgPerson.person.orgName"
+                    v-model="orgPerson.officer.orgName"
                     :rules="orgNameRules"
                   />
                 </div>
@@ -77,11 +77,11 @@
                   <v-col cols="4">
                     <div :class="{'highlightedRole':
                       isRoleLocked(Roles.INCORPORATOR) ||
-                      orgPerson.person.partyType === IncorporatorTypes.CORPORATION}">
+                      orgPerson.officer.partyType === IncorporatorTypes.CORPORATION}">
                       <v-checkbox v-model="isIncorporator"
                       :label="incorporatorLabel"
                       :disabled="isRoleLocked(Roles.INCORPORATOR) ||
-                      orgPerson.person.partyType === IncorporatorTypes.CORPORATION"
+                      orgPerson.officer.partyType === IncorporatorTypes.CORPORATION"
                       />
                     </div>
                   </v-col>
@@ -239,7 +239,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
   private created (): void {
     if (this.initialValue) {
       this.orgPerson = { ...this.initialValue }
-      this.orgPerson.person = { ...this.initialValue.person }
+      this.orgPerson.officer = { ...this.initialValue.officer }
       this.isDirector = this.orgPerson.roles.includes(Roles.DIRECTOR)
       this.isIncorporator = this.orgPerson.roles.includes(Roles.INCORPORATOR)
       this.isCompletingParty = this.orgPerson.roles.includes(Roles.COMPLETING_PARTY)
@@ -270,7 +270,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
 
   private assignCompletingPartyRole (): void {
     if (this.isCompletingParty && this.existingCompletingParty &&
-      this.orgPerson.person.id !== this.existingCompletingParty.person.id) {
+      this.orgPerson.officer.id !== this.existingCompletingParty.officer.id) {
       this.confirmReassignPerson()
     }
   }
@@ -321,9 +321,9 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
    */
   private addPerson (): OrgPersonIF {
     let personToAdd: OrgPersonIF = { ...this.orgPerson }
-    personToAdd.person = { ...this.orgPerson.person }
+    personToAdd.officer = { ...this.orgPerson.officer }
     if (this.activeIndex === -1) {
-      personToAdd.person.id = this.nextId
+      personToAdd.officer.id = this.nextId
     }
     personToAdd.mailingAddress = { ...this.inProgressMailingAddress }
     if (this.isDirector) personToAdd.deliveryAddress = this.setPersonDeliveryAddress()
@@ -373,18 +373,18 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
 
   private reassignPersonErrorMessage () : string {
     let errorMessage: string =
-    `<p>The Completing Party role is already assigned to ${this.existingCompletingParty.person.firstName}
-     ${this.existingCompletingParty.person.middleName || ''} ${this.existingCompletingParty.person.lastName}.</p>
+    `<p>The Completing Party role is already assigned to ${this.existingCompletingParty.officer.firstName}
+     ${this.existingCompletingParty.officer.middleName || ''} ${this.existingCompletingParty.officer.lastName}.</p>
      <p>Selecting "Completing Party" here will change the Completing Party.</p>`
     return errorMessage
   }
 
   get isPerson (): boolean {
-    return this.orgPerson.person?.partyType === IncorporatorTypes.PERSON
+    return this.orgPerson.officer?.partyType === IncorporatorTypes.PERSON
   }
 
   get isOrg (): boolean {
-    return this.orgPerson.person?.partyType === IncorporatorTypes.CORPORATION
+    return this.orgPerson.officer?.partyType === IncorporatorTypes.CORPORATION
   }
 
   get incorporatorLabel () : string {

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -243,9 +243,9 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
       this.isDirector = this.orgPerson.roles.includes(Roles.DIRECTOR)
       this.isIncorporator = this.orgPerson.roles.includes(Roles.INCORPORATOR)
       this.isCompletingParty = this.orgPerson.roles.includes(Roles.COMPLETING_PARTY)
-      this.inProgressMailingAddress = { ...this.orgPerson.address.mailingAddress }
+      this.inProgressMailingAddress = { ...this.orgPerson.mailingAddress }
       if (this.isDirector) {
-        this.inProgressDeliveryAddress = { ...this.orgPerson.address.deliveryAddress }
+        this.inProgressDeliveryAddress = { ...this.orgPerson.deliveryAddress }
         this.inheritMailingAddress = this.isSame(this.inProgressMailingAddress, this.inProgressDeliveryAddress)
       }
     }
@@ -325,22 +325,17 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     if (this.activeIndex === -1) {
       personToAdd.person.id = this.nextId
     }
-    personToAdd.address = this.setPersonAddress()
+    personToAdd.mailingAddress = { ...this.inProgressMailingAddress }
+    if (this.isDirector) personToAdd.deliveryAddress = this.setPersonDeliveryAddress()
     personToAdd.roles = this.setPersonRoles()
     return personToAdd
   }
 
-  private setPersonAddress (): BaseAddressObjIF {
-    let personAddress: BaseAddressObjIF = {
-      mailingAddress: { ...this.inProgressMailingAddress }
+  private setPersonDeliveryAddress (): AddressIF {
+    if (this.inheritMailingAddress) {
+      this.inProgressDeliveryAddress = this.inProgressMailingAddress
     }
-    if (this.isDirector) {
-      if (this.inheritMailingAddress) {
-        this.inProgressDeliveryAddress = this.inProgressMailingAddress
-      }
-      personAddress = { ...personAddress, deliveryAddress: { ...this.inProgressDeliveryAddress } }
-    }
-    return personAddress
+    return { ...this.inProgressDeliveryAddress }
   }
 
   private setPersonRoles (): Roles [] {

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -1,4 +1,3 @@
-import {Roles} from '@/enums';
 <template>
   <div>
     <p>
@@ -78,12 +77,16 @@ import {Roles} from '@/enums';
 // Libraries
 import { Component, Mixins } from 'vue-property-decorator'
 import { Action, State } from 'vuex-class'
+
 // Interfaces
 import { ActionBindingIF, BaseAddressType, FormType, OrgPersonIF, RolesIF } from '@/interfaces'
+
 // Mixins
 import { EntityFilterMixin } from '@/mixins'
+
 // Enums
 import { EntityTypes, IncorporatorTypes, Modes, Roles } from '@/enums'
+
 // Components
 import OrgPerson from './OrgPerson.vue'
 import ListPeopleAndRoles from './ListPeopleAndRoles.vue'

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -110,7 +110,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   @Action setAddPeopleAndRoleStepValidity!: ActionBindingIF
 
   private newOrgPerson: OrgPersonIF = {
-    person: {
+    officer: {
       id: null,
       firstName: '',
       lastName: '',
@@ -148,10 +148,10 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   private addOrgPerson (rolesToInitialize: Roles[], type: IncorporatorTypes): void {
     this.currentOrgPerson = { ...this.newOrgPerson }
     this.currentOrgPerson.roles = rolesToInitialize
-    this.currentOrgPerson.person.partyType = type
+    this.currentOrgPerson.officer.partyType = type
     this.activeIndex = -1
     this.nextId = (this.orgPersonList.length === 0)
-      ? 0 : this.orgPersonList[this.orgPersonList.length - 1].person.id + 1
+      ? 0 : this.orgPersonList[this.orgPersonList.length - 1].officer.id + 1
     this.addEditInProgress = true
     this.showOrgPersonForm = true
   }

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -119,16 +119,14 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
       partyType: null
     },
     roles: [],
-    address: {
-      mailingAddress: {
-        streetAddress: '',
-        streetAddressAdditional: '',
-        addressCity: '',
-        addressRegion: '',
-        postalCode: '',
-        addressCountry: '',
-        deliveryInstructions: ''
-      }
+    mailingAddress: {
+      streetAddress: '',
+      streetAddressAdditional: '',
+      addressCity: '',
+      addressRegion: '',
+      postalCode: '',
+      addressCountry: '',
+      deliveryInstructions: ''
     }
   }
 

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -1,3 +1,4 @@
+import {Roles} from '@/enums';
 <template>
   <div>
     <p>
@@ -23,7 +24,8 @@
       </li>
     </ul>
     <div class="btn-panel" v-if="orgPersonList.length === 0">
-      <v-btn outlined color="primary" @click="addOrgPerson([ Roles.COMPLETING_PARTY ], IncorporatorTypes.PERSON)"
+      <v-btn outlined color="primary"
+      @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
       :disabled="showOrgPersonForm" id="btn-start-add-cp">
         <v-icon>mdi-account-plus-outline</v-icon>
         <span>Start by Adding the Completing Party</span>
@@ -36,12 +38,13 @@
         <span>Add a Person</span>
       </v-btn>
       <v-btn outlined color="primary" :disabled="showOrgPersonForm" class="spacedButton"
-      @click="addOrgPerson([Roles.INCORPORATOR], IncorporatorTypes.CORPORATION)" id="btn-add-corp">
+      @click="addOrgPerson([{ roleType: Roles.INCORPORATOR }], IncorporatorTypes.CORPORATION)" id="btn-add-corp">
         <v-icon>mdi-domain-plus</v-icon>
         <span v-if="entityFilter(EntityTypes.BCOMP)">Add a Corporation or Firm</span>
         <span v-if="entityFilter(EntityTypes.COOP)">Add Organization</span>
       </v-btn>
-      <v-btn outlined color="primary" @click="addOrgPerson([Roles.COMPLETING_PARTY], IncorporatorTypes.PERSON)"
+      <v-btn outlined color="primary"
+      @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
       :disabled="showOrgPersonForm"  class="spacedButton" v-if="!hasRole(Roles.COMPLETING_PARTY, 1, 'ATLEAST')"
       id="btn-add-cp">
         <v-icon>mdi-account-plus-outline</v-icon>
@@ -75,16 +78,12 @@
 // Libraries
 import { Component, Mixins } from 'vue-property-decorator'
 import { Action, State } from 'vuex-class'
-
 // Interfaces
-import { OrgPersonIF, BaseAddressType, FormType, ActionBindingIF } from '@/interfaces'
-
+import { ActionBindingIF, BaseAddressType, FormType, OrgPersonIF, RolesIF } from '@/interfaces'
 // Mixins
 import { EntityFilterMixin } from '@/mixins'
-
 // Enums
-import { EntityTypes, Roles, IncorporatorTypes, Modes } from '@/enums'
-
+import { EntityTypes, IncorporatorTypes, Modes, Roles } from '@/enums'
 // Components
 import OrgPerson from './OrgPerson.vue'
 import ListPeopleAndRoles from './ListPeopleAndRoles.vue'
@@ -145,7 +144,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   }
 
   // Methods
-  private addOrgPerson (rolesToInitialize: Roles[], type: IncorporatorTypes): void {
+  private addOrgPerson (rolesToInitialize: RolesIF[], type: IncorporatorTypes): void {
     this.currentOrgPerson = { ...this.newOrgPerson }
     this.currentOrgPerson.roles = rolesToInitialize
     this.currentOrgPerson.officer.partyType = type
@@ -187,10 +186,10 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
 
   private removeCompletingPartyAssignment () {
     let newList: OrgPersonIF[] = Object.assign([], this.orgPersonList)
-    const cpList = newList.filter(people => people.roles.includes(Roles.COMPLETING_PARTY))
+    const cpList = newList.filter(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY))
     if (cpList.length > 0) {
       let completingParty : OrgPersonIF = cpList[0]
-      completingParty.roles = completingParty.roles.filter(role => role !== Roles.COMPLETING_PARTY)
+      completingParty.roles = completingParty.roles.filter(party => party.roleType !== Roles.COMPLETING_PARTY)
       this.setOrgPersonList(newList)
     }
   }
@@ -204,11 +203,11 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
 
   private hasValidRoles () : boolean {
     const numOfDirector: number =
-    this.orgPersonList.filter(people => people.roles.includes(Roles.DIRECTOR)).length
+    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.DIRECTOR)).length
     const numOfIncorporator: number =
-    this.orgPersonList.filter(people => people.roles.includes(Roles.INCORPORATOR)).length
+    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.INCORPORATOR)).length
     const numOfCompletingParty: number =
-    this.orgPersonList.filter(people => people.roles.includes(Roles.COMPLETING_PARTY)).length
+    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY)).length
     const numOfPeopleWithNoRoles:number =
     this.orgPersonList.filter(people => people.roles.length === 0).length
 
@@ -221,7 +220,8 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
 
   private hasRole (roleName: Roles, count:number, mode:string) : boolean {
     const orgPersonWithSpecifiedRole: OrgPersonIF[] =
-    this.orgPersonList.filter(people => people.roles.includes(roleName))
+    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === roleName))
+
     if (mode === Modes.EXACT) {
       return orgPersonWithSpecifiedRole.length === count
     } else if (mode === Modes.AT_LEAST) {
@@ -234,7 +234,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   }
 
   private get completingParty () : OrgPersonIF {
-    return this.orgPersonList.find(people => people.roles.includes(Roles.COMPLETING_PARTY))
+    return this.orgPersonList.find(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY))
   }
 }
 </script>

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -501,7 +501,7 @@ label:first-child {
 }
 .records-inherit-checkbox {
   margin-top: 0rem;
-  margin-left: 4.65rem;
+  margin-left: 4.5rem;
   margin-bottom: -1.5rem;
   padding: 0;
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -22,6 +22,7 @@ export * from './stepper-interfaces/AddPeopleAndRole/org-person-interface'
 export * from './stepper-interfaces/AddPeopleAndRole/add-people-role-interface'
 export * from './stepper-interfaces/CreateShareStructure/create-share-structure-interface'
 export * from './stepper-interfaces/ReviewConfirm/certify-interface'
+export * from './stepper-interfaces/AddPeopleAndRole/roles-array-interface'
 
 // Others
 export * from './resource-interfaces/component-resource-interfaces/certifyStatement-interface'

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
@@ -2,7 +2,7 @@ import { AddressIF } from '@/interfaces'
 import { Roles, IncorporatorTypes } from '@/enums'
 
 export interface OrgPersonIF {
-  person: {
+  officer: {
     id: number | null
     partyType: IncorporatorTypes;
     firstName: string;

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
@@ -1,5 +1,5 @@
-import { AddressIF } from '@/interfaces'
-import { Roles, IncorporatorTypes } from '@/enums'
+import { AddressIF, RolesIF } from '@/interfaces'
+import { IncorporatorTypes } from '@/enums'
 
 export interface OrgPersonIF {
   officer: {
@@ -10,7 +10,7 @@ export interface OrgPersonIF {
     lastName: string;
     orgName: string
   },
-  roles: Roles[];
+  roles: RolesIF[];
   mailingAddress: AddressIF;
   deliveryAddress?: AddressIF;
 }

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/org-person-interface.ts
@@ -1,4 +1,4 @@
-import { BaseAddressObjIF } from '@/interfaces'
+import { AddressIF } from '@/interfaces'
 import { Roles, IncorporatorTypes } from '@/enums'
 
 export interface OrgPersonIF {
@@ -11,5 +11,6 @@ export interface OrgPersonIF {
     orgName: string
   },
   roles: Roles[];
-  address: BaseAddressObjIF;
+  mailingAddress: AddressIF;
+  deliveryAddress?: AddressIF;
 }

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/roles-array-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/roles-array-interface.ts
@@ -1,0 +1,7 @@
+import { Roles } from '@/enums'
+
+export interface RolesIF {
+  roleType: Roles;
+  appointmentDate?: string;
+  cessationDate?: string;
+}

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -73,7 +73,11 @@ export default class FilingTemplateMixin extends Vue {
       this.setOfficeAddresses(draftFiling.incorporationApplication.offices)
 
       // Set Contact Info
-      this.setBusinessContact(draftFiling.incorporationApplication.contactPoint)
+      const draftContact = {
+        ...draftFiling.incorporationApplication.contactPoint,
+        confirmEmail: draftFiling.incorporationApplication.contactPoint.email
+      }
+      this.setBusinessContact(draftContact)
 
       // Set Persons and Organizations
       this.setOrgPersonList(draftFiling.incorporationApplication.parties)

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -48,6 +48,13 @@ export const isTypeCoop = (state: any): boolean => {
 }
 
 /**
+ *
+ */
+export const getCurrentDate = (state: any): string => {
+  return state.stateModel.currentDate
+}
+
+/**
  * Return a filingId if it exists
  */
 export const getFilingId = (state: any): number => {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -48,7 +48,7 @@ export const isTypeCoop = (state: any): boolean => {
 }
 
 /**
- *
+ * Return the current date
  */
 export const getCurrentDate = (state: any): string => {
   return state.stateModel.currentDate

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ import { stateModel, resourceModel } from './state'
 import { isRoleStaff, isRoleEdit, isRoleView, isEntityType, isTypeBcomp, isTypeCoop,
   isShowBackBtn, isShowReviewConfirmBtn, isShowFilePayBtn, isEnableFilePayBtn, isBusySaving,
   getFilingId, getBusinessIdentifier, getOfficeAddresses, isApplicationValid, getSteps,
-  getMaxStep } from '@/store/getters'
+  getMaxStep, getCurrentDate } from '@/store/getters'
 
 // Mutations
 import { mutateCurrentStep, mutateIsSaving, mutateIsSavingResuming, mutateIsFilingPaying,
@@ -54,7 +54,8 @@ export const store: Store<any> = new Vuex.Store<any>({
     getOfficeAddresses,
     isApplicationValid,
     getSteps,
-    getMaxStep
+    getMaxStep,
+    getCurrentDate
   },
   mutations: {
     mutateCurrentStep,

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -52,6 +52,7 @@ describe('App component', () => {
       incorporationApplication: {
         contactPoint: {
           email: 'mockEmail@mock.com',
+          confirmEmail: 'mockEmail@mock.com',
           phone: '(250) 123-4567'
         },
         nameRequest: {
@@ -102,11 +103,11 @@ describe('App component', () => {
 
     // Validate Office Addresses
     expect(store.state.stateModel.defineCompanyStep.officeAddresses.registeredOffice)
-      .toBe(data.incorporationApplication.offices.registeredOffice)
+      .toStrictEqual(data.incorporationApplication.offices.registeredOffice)
     expect(store.state.stateModel.defineCompanyStep.officeAddresses.recordsOffice)
-      .toBe(data.incorporationApplication.offices.recordsOffice)
+      .toStrictEqual(data.incorporationApplication.offices.recordsOffice)
 
     // Validate Contact Info
-    expect(store.state.stateModel.defineCompanyStep.businessContact).toBe(data.incorporationApplication.contactPoint)
+    expect(store.state.stateModel.defineCompanyStep.businessContact).toStrictEqual(data.incorporationApplication.contactPoint)
   })
 })

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -24,7 +24,7 @@ describe('List People And Roles', () => {
 
   const mockPersonList = [
     {
-      'person': {
+      'officer': {
         'id': 0,
         'firstName': 'Cameron',
         'lastName': 'Bowler',
@@ -54,7 +54,7 @@ describe('List People And Roles', () => {
       }
     },
     {
-      'person': {
+      'officer': {
         'id': 1,
         'firstName': '',
         'lastName': '',

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -33,8 +33,8 @@ describe('List People And Roles', () => {
         'partyType': 'Person'
       },
       'roles': [
-        'Completing Party',
-        'Director'
+        { 'roleType': 'Completing Party', 'appointmentDate': '2020-03-30' },
+        { 'roleType': 'Director', 'appointmentDate': '2020-03-30' }
       ],
       'mailingAddress': {
         'streetAddress': '122-12210 Boul De Pierrefonds',
@@ -63,7 +63,7 @@ describe('List People And Roles', () => {
         'partyType': 'Org'
       },
       'roles': [
-        'Incorporator'
+        { 'roleType': 'Incorporator', 'appointmentDate': '2020-03-30' }
       ],
       'mailingAddress': {
         'streetAddress': '12-1044 Boul 21De Normandie',

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -36,23 +36,21 @@ describe('List People And Roles', () => {
         'Completing Party',
         'Director'
       ],
-      'address': {
-        'mailingAddress': {
-          'streetAddress': '122-12210 Boul De Pierrefonds',
-          'streetAddressAdditional': '',
-          'addressCity': 'Pierrefonds',
-          'addressRegion': 'QC',
-          'postalCode': 'H9A 2X6',
-          'addressCountry': 'CA'
-        },
-        'deliveryAddress': {
-          'streetAddress': '122-12210 Boul De Pierrefonds',
-          'streetAddressAdditional': '',
-          'addressCity': 'Pierrefonds',
-          'addressRegion': 'QC',
-          'postalCode': 'H9A 2X6',
-          'addressCountry': 'CA'
-        }
+      'mailingAddress': {
+        'streetAddress': '122-12210 Boul De Pierrefonds',
+        'streetAddressAdditional': '',
+        'addressCity': 'Pierrefonds',
+        'addressRegion': 'QC',
+        'postalCode': 'H9A 2X6',
+        'addressCountry': 'CA'
+      },
+      'deliveryAddress': {
+        'streetAddress': '122-12210 Boul De Pierrefonds',
+        'streetAddressAdditional': '',
+        'addressCity': 'Pierrefonds',
+        'addressRegion': 'QC',
+        'postalCode': 'H9A 2X6',
+        'addressCountry': 'CA'
       }
     },
     {
@@ -67,15 +65,13 @@ describe('List People And Roles', () => {
       'roles': [
         'Incorporator'
       ],
-      'address': {
-        'mailingAddress': {
-          'streetAddress': '12-1044 Boul 21De Normandie',
-          'streetAddressAdditional': '',
-          'addressCity': 'Saint-Jean-Sur-Richelieu',
-          'addressRegion': 'QC',
-          'postalCode': 'J3A 1H7',
-          'addressCountry': 'CA'
-        }
+      'mailingAddress': {
+        'streetAddress': '12-1044 Boul 21De Normandie',
+        'streetAddressAdditional': '',
+        'addressCity': 'Saint-Jean-Sur-Richelieu',
+        'addressRegion': 'QC',
+        'postalCode': 'J3A 1H7',
+        'addressCountry': 'CA'
       }
     }
   ]
@@ -156,7 +152,7 @@ describe('List People And Roles', () => {
   })
 
   it('displays the correct addresses text when mailing and delivery do NOT match', () => {
-    mockPersonList[0].address.deliveryAddress.streetAddress = '123 Different rd'
+    mockPersonList[0].deliveryAddress.streetAddress = '123 Different rd'
     // Mounting the Wrapper to allow for the test to reach into the baseAddress component to validate data
     const wrapper = mount(ListPeopleAndRoles, { propsData: { personList: mockPersonList }, vuetify })
 

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -32,7 +32,7 @@ const cancelButtonSelector: string = '#btn-cancel'
 const formSelector: string = '.appoint-form'
 
 const validPersonData = {
-  'person': {
+  'officer': {
     'id': 0,
     'firstName': 'Adam',
     'lastName': 'Smith',
@@ -60,7 +60,7 @@ const validPersonData = {
 }
 
 const validIncorporator = {
-  'person': {
+  'officer': {
     'id': 1,
     'firstName': 'Adam',
     'lastName': 'Smith',
@@ -88,7 +88,7 @@ const validIncorporator = {
 }
 
 const validOrgData = {
-  'person': {
+  'officer': {
     'id': 0,
     'firstName': '',
     'lastName': '',
@@ -174,7 +174,7 @@ describe('OrgPerson', () => {
   it('Displays form data for org', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validOrgData, -1, 0, null)
     expect((<HTMLInputElement> wrapper.find(orgNameSelector).element).value)
-      .toEqual(validOrgData['person']['orgName'])
+      .toEqual(validOrgData['officer']['orgName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeDefined()
@@ -185,11 +185,11 @@ describe('OrgPerson', () => {
   it('Displays form data for person', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validPersonData, 0, 0, null)
     expect((<HTMLInputElement> wrapper.find(firstNameSelector).element).value)
-      .toEqual(validPersonData['person']['firstName'])
+      .toEqual(validPersonData['officer']['firstName'])
     expect((<HTMLInputElement> wrapper.find(middleNameSelector).element).value)
-      .toEqual(validPersonData['person']['middleName'])
+      .toEqual(validPersonData['officer']['middleName'])
     expect((<HTMLInputElement> wrapper.find(lastNameSelector).element).value)
-      .toEqual(validPersonData['person']['lastName'])
+      .toEqual(validPersonData['officer']['lastName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeUndefined()
@@ -220,7 +220,7 @@ describe('OrgPerson', () => {
   it('Clicking Done button emits event for add edit person/org', async () => {
     const wrapper: Wrapper<OrgPerson> = createComponent(validOrgData, -1, 0, null)
     expect((<HTMLInputElement> wrapper.find(orgNameSelector).element).value)
-      .toEqual(validOrgData['person']['orgName'])
+      .toEqual(validOrgData['officer']['orgName'])
     await wrapper.vm.$nextTick()
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     wrapper.find(doneButtonSelector).trigger('click')

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -41,23 +41,21 @@ const validPersonData = {
     'partyType': 'Person'
   },
   'roles': ['Director', 'Completing Party'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    },
-    'deliveryAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
+  },
+  'deliveryAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -71,23 +69,21 @@ const validIncorporator = {
     'partyType': 'Person'
   },
   'roles': ['Incorporator'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    },
-    'deliveryAddress': {
-      'streetAddress': '123 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
+  },
+  'deliveryAddress': {
+    'streetAddress': '123 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -101,15 +97,13 @@ const validOrgData = {
     'partyType': 'Org'
   },
   'roles': ['Incorporator'],
-  'address': {
-    'mailingAddress': {
-      'streetAddress': '3942 Fake Street',
-      'streetAddressAdditional': '',
-      'addressCity': 'Victoria',
-      'addressRegion': 'BC',
-      'postalCode': 'V8Z 5C6',
-      'addressCountry': 'CA'
-    }
+  'mailingAddress': {
+    'streetAddress': '3942 Fake Street',
+    'streetAddressAdditional': '',
+    'addressCity': 'Victoria',
+    'addressRegion': 'BC',
+    'postalCode': 'V8Z 5C6',
+    'addressCountry': 'CA'
   }
 }
 
@@ -294,7 +288,6 @@ describe('OrgPerson', () => {
     expect(wrapper.emitted(addEditPersonEvent).length).toBe(1)
     let incorporatorWithAddedRole = { ...validIncorporator }
     incorporatorWithAddedRole.roles = ['Completing Party', 'Incorporator']
-    delete incorporatorWithAddedRole.address.deliveryAddress
 
     expect(wrapper.emitted(addEditPersonEvent)[0][0]).toStrictEqual(incorporatorWithAddedRole)
 

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -40,7 +40,10 @@ const validPersonData = {
     'orgName': '',
     'partyType': 'Person'
   },
-  'roles': ['Director', 'Completing Party'],
+  'roles': [
+    { 'roleType': 'Director', 'appointmentDate': '2020-03-30' },
+    { 'roleType': 'Completing Party', 'appointmentDate': '2020-03-30' }
+  ],
   'mailingAddress': {
     'streetAddress': '123 Fake Street',
     'streetAddressAdditional': '',
@@ -68,7 +71,9 @@ const validIncorporator = {
     'orgName': '',
     'partyType': 'Person'
   },
-  'roles': ['Incorporator'],
+  'roles': [
+    { 'roleType': 'Incorporator', 'appointmentDate': '2020-03-30' }
+  ],
   'mailingAddress': {
     'streetAddress': '123 Fake Street',
     'streetAddressAdditional': '',
@@ -96,7 +101,9 @@ const validOrgData = {
     'orgName': 'Test Org',
     'partyType': 'Org'
   },
-  'roles': ['Incorporator'],
+  'roles': [
+    { 'roleType': 'Incorporator', 'appointmentDate': '2020-03-30' }
+  ],
   'mailingAddress': {
     'streetAddress': '3942 Fake Street',
     'streetAddressAdditional': '',
@@ -150,6 +157,7 @@ function createComponent (
 }
 
 store.state.stateModel.nameRequest.entityType = 'BCOMP'
+store.state.stateModel.currentDate = '2020-03-30'
 
 describe('OrgPerson', () => {
   it('Loads the component and sets data for person', async () => {
@@ -287,7 +295,10 @@ describe('OrgPerson', () => {
     expect(wrapper.emitted().addEditPerson).toBeTruthy()
     expect(wrapper.emitted(addEditPersonEvent).length).toBe(1)
     let incorporatorWithAddedRole = { ...validIncorporator }
-    incorporatorWithAddedRole.roles = ['Completing Party', 'Incorporator']
+    incorporatorWithAddedRole.roles = [
+      { roleType: 'Completing Party', appointmentDate: '2020-03-30' },
+      { roleType: 'Incorporator', appointmentDate: '2020-03-30' }
+    ]
 
     expect(wrapper.emitted(addEditPersonEvent)[0][0]).toStrictEqual(incorporatorWithAddedRole)
 

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -13,6 +13,7 @@ import { createLocalVue, mount, shallowMount } from '@vue/test-utils'
 
 // Components
 import { PeopleAndRoles } from '@/components/AddPeopleAndRoles'
+import { RolesIF } from '@/interfaces'
 
 Vue.use(Vuetify)
 Vue.use(Vuelidate)
@@ -29,7 +30,7 @@ const appointForm: string = '.appoint-form'
 const checkCompletingParty: string = '.cp-valid'
 const checkDirector: string = '.dir-valid'
 const checkIncorporator: string = '.incorp-valid'
-const completingPartyRole: string = 'Completing Party'
+const completingPartyRole = { 'roleType': 'Completing Party', 'appointmentDate': '2020-03-30' }
 const directorRole: string = 'Director'
 const incorporatorRole: string = 'Incorporator'
 
@@ -37,7 +38,7 @@ function resetStore (): void {
   store.state.stateModel.addPeopleAndRoleStep.orgPeople = []
 }
 
-function getPersonList (roles: string[] = [completingPartyRole]) : any {
+function getPersonList (roles = [completingPartyRole]) : any {
   const mockPersonList = [
     {
       'officer': {
@@ -125,7 +126,9 @@ describe('People And Roles', () => {
   })
 
   it('shows Add Completing Party Button when people list is not empty and has no Completing Party', () => {
-    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList(['Director'])
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList([
+      { 'roleType': 'Director', 'appointmentDate': '2020-03-30' }
+    ])
     const wrapper = wrapperFactory()
     expect(wrapper.find(btnAddCompletingParty).exists()).toBeTruthy()
     wrapper.destroy()
@@ -163,7 +166,10 @@ describe('People And Roles', () => {
   })
 
   it('Shows check mark next to roles added', () => {
-    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList(['Director', 'Incorporator'])
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList([
+      { 'roleType': 'Director', 'appointmentDate': '2020-03-30' },
+      { 'roleType': 'Incorporator', 'appointmentDate': '2020-03-30' }
+    ])
     const wrapper = wrapperFactory()
     expect(wrapper.find(checkIncorporator).exists()).toBeTruthy()
     expect(wrapper.find(checkDirector).exists()).toBeTruthy()

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -40,7 +40,7 @@ function resetStore (): void {
 function getPersonList (roles: string[] = [completingPartyRole]) : any {
   const mockPersonList = [
     {
-      'person': {
+      'officer': {
         'id': 0,
         'firstName': 'Adam',
         'lastName': 'Smith',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3134

*Description of changes:*

* Removed the `Address` wrapping in the incorporations filings to match schema.
* Implemented a means of restoring the confirmEmail property when resuming a draft for better UX.
* Refactored `Persons` label into `Officer` to get in sync with the schema.
* Refactored the `Roles` property structure and means of identifying roles in the logic.
* Updated minor styling to align checkboxes.
* Updated Unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
