### PR TITLE
2465 - Display NR Data

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -161,13 +161,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
     // Evaluate name request pre conditions
     const nameRequest = await this.evaluateNRPreconditions()
     if (nameRequest && nameRequest.nrNum && nameRequest.isConsumable) {
-      // TODO: Handling different NR Formats & accept the EntityType dynamically once Namex provides it.
-      // Will probably change once we proxy through legal API with a consistent format
-      this.setNameRequestState(
-        { nrNumber: nameRequest.nrNum,
-          // TODO: Implement this check when POST-MVP: entityType: nameRequest.requestTypeCd,
-          entityType: EntityTypes.BCOMP,
-          filingId: null })
+      this.setNameRequestState(this.generateNameRequestState(nameRequest, null))
       this.setCurrentDate(this.dateToUsableString(new Date()))
 
       try {

--- a/src/components/Summary/SummaryDefineCompany.vue
+++ b/src/components/Summary/SummaryDefineCompany.vue
@@ -20,7 +20,7 @@
           <label><strong>Company Name</strong></label>
         </v-flex>
         <v-flex md8>
-          <div class="company-name">XYZ Inc.</div>
+          <div class="company-name">{{ getApprovedName }}</div>
           <div class="company-type">
             <span v-if="entityFilter(EntityTypes.BCOMP)">BC Benefit Company</span>
             <span v-else-if="entityFilter(EntityTypes.COOP)">BC Cooperative Association</span>
@@ -42,10 +42,10 @@
 <script lang="ts">
 // Libraries
 import { Component, Mixins } from 'vue-property-decorator'
-import { State } from 'vuex-class'
+import { Getter, State } from 'vuex-class'
 
 // Interfaces
-import { BusinessContactIF, IncorporationAddressIf } from '@/interfaces'
+import { BusinessContactIF, GetterIF, IncorporationAddressIf } from '@/interfaces'
 
 // Components
 import { BusinessContactInfo, OfficeAddresses } from '@/components/DefineCompany'
@@ -63,6 +63,9 @@ import { EntityTypes } from '@/enums'
   }
 })
 export default class SummaryDefineCompany extends Mixins(EntityFilterMixin) {
+  // Getters
+  @Getter getApprovedName: GetterIF
+
   // State
   @State(state => state.stateModel.defineCompanyStep.valid)
   readonly valid!: boolean

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -48,7 +48,7 @@ import { Getter } from 'vuex-class'
 import { GetterIF } from '@/interfaces'
 
 @Component
-export default class EntityInfo extends Mixins() {
+export default class EntityInfo extends Vue {
   // Global getters
   @Getter isEntityType!: GetterIF
   @Getter isTypeBcomp!: GetterIF
@@ -57,7 +57,7 @@ export default class EntityInfo extends Mixins() {
   @Getter getApprovedName!: GetterIF
 
   /** The entity title  */
-  entityTitle (): string {
+  private entityTitle (): string {
     if (this.isTypeBcomp) {
       return 'Incorporate a BC Benefit Company'
     } else if (this.isTypeCoop) {

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -15,16 +15,9 @@
 
         <!-- Header With NR Data -->
         <v-list-item-content id="nr-header" v-show="isEntityType">
-
-          <!-- Subtitle -->
-          <v-list-item-subtitle class="entity-subtitle">
-            <span v-if="isTypeBcomp">Incorporate a BC Benefit Company</span>
-            <span v-if="isTypeCoop">Incorporate a BC Cooperative Association</span>
-          </v-list-item-subtitle>
-
           <!-- Company Name -->
           <v-list-item-title class="header-title" id="entity-legal-name">
-            <span>XYZ Inc.</span>
+            <span>{{ getApprovedName }}</span>
           </v-list-item-title>
 
           <!-- TODO: display Designation? See mockup. -->
@@ -32,9 +25,9 @@
           <!-- Company Number -->
           <v-list-item-subtitle class="business-info">
             <dl>
-              <dt>Name Request No:</dt>
+              <dt> {{ entityTitle() }} Name Request No:</dt>
               <dd class="ml-2" id="entity-nr-number">
-                <span>NR1234567</span>
+                <span>{{ getBusinessIdentifier }}</span>
               </dd>
             </dl>
           </v-list-item-subtitle>
@@ -48,19 +41,33 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Vue } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 
 // Interfaces
 import { GetterIF } from '@/interfaces'
 
 @Component
-export default class EntityInfo extends Vue {
+export default class EntityInfo extends Mixins() {
   // Global getters
   @Getter isEntityType!: GetterIF
   @Getter isTypeBcomp!: GetterIF
   @Getter isTypeCoop!: GetterIF
+  @Getter getBusinessIdentifier!: GetterIF
+  @Getter getApprovedName!: GetterIF
+
+  /** The entity title  */
+  entityTitle (): string {
+    if (this.isTypeBcomp) {
+      return 'Incorporate a BC Benefit Company'
+    } else if (this.isTypeCoop) {
+      return 'Incorporate a BC Cooperative Association'
+    }
+
+    return ''
+  }
 }
+
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Mixins, Vue } from 'vue-property-decorator'
+import { Component, Vue } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 
 // Interfaces

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -8,12 +8,12 @@
       </v-col>
       <v-col>
         <ul>
-          <li class="name-request-title mb-4">
+          <li class="name-request-title">
             <strong>{{ getBusinessIdentifier }}</strong> - {{ getNameRequestDetails.approvedName}}
           </li>
-          <li>Entity Type: {{ entityTypeDescription() }}</li>
-          <li class="mb-4"> Request Type: {{ requestType() }}</li>
-          <li>Expiry Date: {{ formattedExpirationDate() }}</li>
+          <li class="mt-4">Entity Type: {{ entityTypeDescription() }}</li>
+          <li> Request Type: {{ requestType() }}</li>
+          <li class="mt-4">Expiry Date: {{ formattedExpirationDate() }}</li>
           <li>Status: {{ getNameRequestDetails.status }}</li>
           <li>Condition/Consent: {{ conditionConsent() }}</li>
         </ul>
@@ -61,10 +61,9 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   @Getter getBusinessIdentifier!: GetterIF;
   @Getter getNameRequestDetails!: NameRequestDetailsIF;
   @Getter getNameRequestApplicant!: NameRequestApplicantIF;
-  getName = getName
 
   /** The entity title  */
-  entityTypeDescription () :string {
+  private entityTypeDescription () :string {
     if (this.isTypeBcomp) {
       return 'BC Benefit Company'
     } else if (this.isTypeCoop) {
@@ -75,17 +74,17 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** The request type */
-  requestType () : string {
+  private requestType () : string {
     return 'New Business'
   }
 
   /** Return formatted expiration date */
-  formattedExpirationDate () : string {
+  private formattedExpirationDate () : string {
     return this.toReadableDate(this.getNameRequestDetails.expirationDate)
   }
 
   /** Return consent received string by checking if conditional and if consent has been received */
-  conditionConsent (): string {
+  private conditionConsent (): string {
     if (this.getNameRequestDetails.status === NameRequestStates.CONDITIONAL) {
       return this.getNameRequestDetails.consentFlag === 'R' ? 'Received' : 'Not Received'
     }
@@ -94,7 +93,7 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** Return formatted applicant name */
-  applicantName () : string {
+  private applicantName () : string {
     let name = this.getNameRequestApplicant.firstName
     if (this.getNameRequestApplicant.middleName) {
       name = `${name} ${this.getNameRequestApplicant.middleName} ${this.getNameRequestApplicant.lastName}`
@@ -105,13 +104,13 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** Return formatted address string */
-  applicantAddress () : string {
+  private applicantAddress () : string {
     // Get Address info
     const city = this.getNameRequestApplicant.city
     const stateProvince = this.getNameRequestApplicant.stateProvinceCode
     const postal = this.getNameRequestApplicant.postalCode
     const country = this.getNameRequestApplicant.countryTypeCode
-      ? this.getName(this.getNameRequestApplicant.countryTypeCode) : ''
+      ? getName(this.getNameRequestApplicant.countryTypeCode) : ''
 
     // Build address lines
     let address = this.getNameRequestApplicant.addressLine1

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -15,7 +15,9 @@
           <li> Request Type: {{ requestType() }}</li>
           <li class="mt-4">Expiry Date: {{ formattedExpirationDate() }}</li>
           <li>Status: {{ getNameRequestDetails.status }}</li>
-          <li>Condition/Consent: {{ conditionConsent() }}</li>
+          <li id="condition-consent" v-if="getNameRequestDetails.status === NameRequestStates.CONDITIONAL">
+            Condition/Consent: {{ conditionConsent() }}
+          </li>
         </ul>
       </v-col>
     </v-row>
@@ -54,6 +56,9 @@ import { DateMixin } from '@/mixins'
 
 @Component
 export default class NameRequestInfo extends Mixins(DateMixin) {
+  // Template Enums
+  readonly NameRequestStates = NameRequestStates
+
   // Global getters
   @Getter isEntityType!: GetterIF;
   @Getter isTypeBcomp!: GetterIF;

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -1,0 +1,146 @@
+<template>
+  <div id="name-request-summary">
+    <v-row id="name-request-info">
+      <v-col>
+        <label>
+          <strong>Name Request</strong>
+        </label>
+      </v-col>
+      <v-col>
+        <ul>
+          <li class="name-request-title mb-4">
+            <strong>{{ getBusinessIdentifier }}</strong> - {{ getNameRequestDetails.approvedName}}
+          </li>
+          <li>Entity Type: {{ entityTypeDescription() }}</li>
+          <li class="mb-4"> Request Type: {{ requestType() }}</li>
+          <li>Expiry Date: {{ formattedExpirationDate() }}</li>
+          <li>Status: {{ getNameRequestDetails.status }}</li>
+          <li>Condition/Consent: {{ conditionConsent() }}</li>
+        </ul>
+      </v-col>
+    </v-row>
+    <v-row id="name-request-applicant-info">
+      <v-col>
+        <label>
+          <strong>Name Request Applicant</strong>
+        </label>
+      </v-col>
+      <v-col>
+        <ul>
+          <li>Name: {{ applicantName() }}</li>
+          <li>Address: {{ applicantAddress() }}</li>
+          <li>Email: {{ getNameRequestApplicant.emailAddress }}</li>
+          <li>Phone: {{ getNameRequestApplicant.phoneNumber }}</li>
+        </ul>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script lang="ts">
+// Libraries
+import { Component, Mixins, Vue } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
+import { getName } from 'country-list'
+
+// Enums
+import { NameRequestStates } from '@/enums'
+
+// Interfaces
+import { GetterIF, NameRequestDetailsIF, NameRequestApplicantIF } from '@/interfaces'
+
+// Mixins
+import { DateMixin } from '@/mixins'
+
+@Component
+export default class NameRequestInfo extends Mixins(DateMixin) {
+  // Global getters
+  @Getter isEntityType!: GetterIF;
+  @Getter isTypeBcomp!: GetterIF;
+  @Getter isTypeCoop!: GetterIF;
+  @Getter getBusinessIdentifier!: GetterIF;
+  @Getter getNameRequestDetails!: NameRequestDetailsIF;
+  @Getter getNameRequestApplicant!: NameRequestApplicantIF;
+  getName = getName
+
+  /** The entity title  */
+  entityTypeDescription () :string {
+    if (this.isTypeBcomp) {
+      return 'BC Benefit Company'
+    } else if (this.isTypeCoop) {
+      return 'BC Cooperative Association'
+    }
+
+    return ''
+  }
+
+  /** The request type */
+  requestType () : string {
+    return 'New Business'
+  }
+
+  /** Return formatted expiration date */
+  formattedExpirationDate () : string {
+    return this.toReadableDate(this.getNameRequestDetails.expirationDate)
+  }
+
+  /** Return consent received string by checking if conditional and if consent has been received */
+  conditionConsent (): string {
+    if (this.getNameRequestDetails.status === NameRequestStates.CONDITIONAL) {
+      return this.getNameRequestDetails.consentFlag === 'R' ? 'Received' : 'Not Received'
+    }
+
+    return ''
+  }
+
+  /** Return formatted applicant name */
+  applicantName () : string {
+    let name = this.getNameRequestApplicant.firstName
+    if (this.getNameRequestApplicant.middleName) {
+      name = `${name} ${this.getNameRequestApplicant.middleName} ${this.getNameRequestApplicant.lastName}`
+    } else {
+      name = `${name} ${this.getNameRequestApplicant.lastName}`
+    }
+    return name
+  }
+
+  /** Return formatted address string */
+  applicantAddress () : string {
+    // Get Address info
+    const city = this.getNameRequestApplicant.city
+    const stateProvince = this.getNameRequestApplicant.stateProvinceCode
+    const postal = this.getNameRequestApplicant.postalCode
+    const country = this.getNameRequestApplicant.countryTypeCode
+      ? this.getName(this.getNameRequestApplicant.countryTypeCode) : ''
+
+    // Build address lines
+    let address = this.getNameRequestApplicant.addressLine1
+    if (this.getNameRequestApplicant.addressLine2) {
+      address = `${address}, ${this.getNameRequestApplicant.addressLine2}`
+    }
+    if (this.getNameRequestApplicant.addressLine3) {
+      address = `${address}, ${this.getNameRequestApplicant.addressLine3}`
+    }
+
+    return `${address}, ${city}, ${stateProvince}, ${postal}, ${country}`
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/styles/theme.scss";
+  .row .col:first-child {
+      width: 12rem;
+      max-width: 12rem;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  li.name-request-title {
+    font-size: 1.25rem;
+  }
+</style>

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,10 +1,12 @@
 import EntityInfo from './EntityInfo.vue'
 import ResourceExample from './ResourceExample.vue'
+import NameRequestInfo from './NameRequestInfo.vue'
 import Stepper from './Stepper.vue'
 import Actions from './Actions.vue'
 
 export {
   EntityInfo,
+  NameRequestInfo,
   ResourceExample,
   Stepper,
   Actions

--- a/src/interfaces/store-interfaces/state-interfaces/name-request-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/name-request-interface.ts
@@ -2,5 +2,31 @@
 export interface NameRequestIF {
   nrNumber: string
   entityType: string
+  details: NameRequestDetailsIF | {}
+  applicant: NameRequestApplicantIF | {}
   filingId: number | null
+}
+
+// Name request response details interface
+export interface NameRequestDetailsIF {
+  approvedName: string
+  status: string
+  consentFlag: string
+  expirationDate: string
+}
+
+// Name request applicant details interface
+export interface NameRequestApplicantIF {
+  firstName: string
+  middleName: string
+  lastName: string
+  emailAddress: string
+  phoneNumber: string
+  addressLine1: string
+  addressLine2: string
+  addressLine3: string
+  city: string
+  countryTypeCode: string
+  postalCode: string
+  stateProvinceCode: string
 }

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -1,7 +1,8 @@
 // Libraries
 import axios from '@/utils/axios-auth'
 import { Component, Vue } from 'vue-property-decorator'
-import { NameRequestStates } from '@/enums/nameRequestStates'
+import { NameRequestStates, EntityTypes } from '@/enums'
+import { NameRequestIF } from '@/interfaces'
 
 /**
  * Name request mixin for processing NR responses
@@ -9,10 +10,50 @@ import { NameRequestStates } from '@/enums/nameRequestStates'
 @Component
 export default class NameRequestMixin extends Vue {
   /**
+   * Generate name request state for the store
+   * @param nr the name request response payload
+   * @param filingId the filing id
+   */
+  generateNameRequestState (nr: any, filingId: number): NameRequestIF {
+    const approvedName = nr.names.filter(name => name.state === NameRequestStates.APPROVED)[0].name
+    return {
+      nrNumber: nr.nrNum,
+      // TODO: Update entityType to use nr.requestTypeCd when namex supports our entity types
+      entityType: EntityTypes.BCOMP,
+      filingId: filingId,
+      applicant: {
+        // Address Information
+        addressLine1: nr.applicants.addrLine1,
+        addressLine2: nr.applicants.addrLine2,
+        addressLine3: nr.applicants.addrLine3,
+        city: nr.applicants.city,
+        countryTypeCode: nr.applicants.countryTypeCd,
+        postalCode: nr.applicants.postalCd,
+        stateProvinceCode: nr.applicants.stateProvinceCd,
+
+        // Application contact information
+        emailAddress: nr.applicants.emailAddress,
+        phoneNumber: nr.applicants.phoneNumber,
+
+        // Application name information
+        firstName: nr.applicants.firstName,
+        middleName: nr.applicants.middleName,
+        lastName: nr.applicants.lastName
+      },
+      details: {
+        approvedName: approvedName,
+        consentFlag: nr.consentFlag,
+        expirationDate: nr.expirationDate,
+        status: nr.state
+      }
+    }
+  }
+  /**
    * Returns True if the Name Request data is valid.
    * @param nr the name request response payload
    * */
   isNrValid (nr: any): boolean {
+    // TODO: implement check for supported entity types when namex supports BCOMP
     return (nr &&
       nr.state &&
       nr.expirationDate &&

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -15,7 +15,7 @@ export default class NameRequestMixin extends Vue {
    * @param filingId the filing id
    */
   generateNameRequestState (nr: any, filingId: number): NameRequestIF {
-    const approvedName = nr.names.filter(name => name.state === NameRequestStates.APPROVED)[0].name
+    const approvedName = nr.names.find(name => name.state === NameRequestStates.APPROVED).name
     return {
       nrNumber: nr.nrNum,
       // TODO: Update entityType to use nr.requestTypeCd when namex supports our entity types

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -4,6 +4,7 @@
 
 // Enums
 import { EntityTypes } from '@/enums'
+import { NameRequestDetailsIF, NameRequestApplicantIF } from '@/interfaces'
 
 /**
  * Whether the client has staff keycloak role
@@ -66,6 +67,27 @@ export const getFilingId = (state: any): number => {
  */
 export const getBusinessIdentifier = (state: any): string => {
   return state.stateModel.nameRequest.nrNumber
+}
+
+/**
+ * Return an approved name request name if it exists
+ */
+export const getApprovedName = (state: any): string => {
+  return state.stateModel.nameRequest.details.approvedName
+}
+
+/**
+ * Return name request details if they exist
+ */
+export const getNameRequestDetails = (state: any): NameRequestDetailsIF => {
+  return state.stateModel.nameRequest.details
+}
+
+/**
+ * Return a name request applicant information if it exists
+ */
+export const getNameRequestApplicant = (state: any): NameRequestApplicantIF => {
+  return state.stateModel.nameRequest.applicant
 }
 
 /**

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -56,35 +56,35 @@ export const getCurrentDate = (state: any): string => {
 }
 
 /**
- * Return a filingId if it exists
+ * Return a filingId
  */
 export const getFilingId = (state: any): number => {
   return state.stateModel.nameRequest.filingId
 }
 
 /**
- * Return a business identifier if it exists
+ * Return a business identifier
  */
 export const getBusinessIdentifier = (state: any): string => {
   return state.stateModel.nameRequest.nrNumber
 }
 
 /**
- * Return an approved name request name if it exists
+ * Return the approved name of a name request
  */
 export const getApprovedName = (state: any): string => {
   return state.stateModel.nameRequest.details.approvedName
 }
 
 /**
- * Return name request details if they exist
+ * Return name request details
  */
 export const getNameRequestDetails = (state: any): NameRequestDetailsIF => {
   return state.stateModel.nameRequest.details
 }
 
 /**
- * Return a name request applicant information if it exists
+ * Return name request applicant information
  */
 export const getNameRequestApplicant = (state: any): NameRequestApplicantIF => {
   return state.stateModel.nameRequest.applicant

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,8 +9,9 @@ import { stateModel, resourceModel } from './state'
 // Getters
 import { isRoleStaff, isRoleEdit, isRoleView, isEntityType, isTypeBcomp, isTypeCoop,
   isShowBackBtn, isShowReviewConfirmBtn, isShowFilePayBtn, isEnableFilePayBtn, isBusySaving,
-  getFilingId, getBusinessIdentifier, getOfficeAddresses, isApplicationValid, getSteps,
-  getMaxStep, getCurrentDate } from '@/store/getters'
+  getFilingId, getBusinessIdentifier, getApprovedName, getNameRequestDetails, getNameRequestApplicant,
+  getOfficeAddresses, isApplicationValid, getSteps, getMaxStep, getCurrentDate }
+  from '@/store/getters'
 
 // Mutations
 import { mutateCurrentStep, mutateIsSaving, mutateIsSavingResuming, mutateIsFilingPaying,
@@ -49,8 +50,11 @@ export const store: Store<any> = new Vuex.Store<any>({
     isShowFilePayBtn,
     isEnableFilePayBtn,
     isBusySaving,
-    getFilingId,
+    getApprovedName,
     getBusinessIdentifier,
+    getFilingId,
+    getNameRequestApplicant,
+    getNameRequestDetails,
     getOfficeAddresses,
     isApplicationValid,
     getSteps,

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -1,4 +1,4 @@
-import { StateModelIF } from '@/interfaces'
+import { StateModelIF, NameRequestApplicantIF, NameRequestDetailsIF } from '@/interfaces'
 
 export const stateModel: StateModelIF = {
   tombstone: {
@@ -9,8 +9,8 @@ export const stateModel: StateModelIF = {
   nameRequest: {
     nrNumber: '',
     entityType: '',
-    details: {},
-    applicant: {},
+    details: {} as NameRequestDetailsIF,
+    applicant: {} as NameRequestApplicantIF,
     filingId: null
   },
   currentDate: '',

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -9,6 +9,8 @@ export const stateModel: StateModelIF = {
   nameRequest: {
     nrNumber: '',
     entityType: '',
+    details: {},
+    applicant: {},
     filingId: null
   },
   currentDate: '',

--- a/src/views/DefineCompany.vue
+++ b/src/views/DefineCompany.vue
@@ -5,28 +5,7 @@
         <h2>1. Company Name</h2>
       </header>
       <v-card flat class="step-container">
-        <div class="meta-container">
-          <label>Name Request</label>
-
-          <div class="value name-request">
-            <p>Generate a Name Request (NR):</p>
-
-            <v-container id="business-buttons-container" class="list-item justify-space-between">
-              <v-btn id="select-bc-btn" large color="primary" :disabled="isEntityType" @click="onClickBC()">
-                <span class="font-weight-bold">Benefit Company NR</span>
-              </v-btn>
-
-              <v-btn id="select-cp-btn" large color="success" :disabled="isEntityType" @click="onClickCP()">
-                <span class="font-weight-bold">Cooperative Association NR</span>
-              </v-btn>
-
-              <v-btn id="reset-btn" large :disabled="!isEntityType" @click="onClickReset()">
-                <v-icon>mdi-undo</v-icon>
-                <span>Reset</span>
-              </v-btn>
-            </v-container>
-          </div>
-        </div>
+          <name-request-info />
       </v-card>
     </section>
 
@@ -79,10 +58,12 @@ import { EntityTypes } from '@/enums'
 
 // Components
 import { BusinessContactInfo, OfficeAddresses } from '@/components/DefineCompany'
+import { NameRequestInfo } from '@/components/common'
 
 @Component({
   components: {
     BusinessContactInfo,
+    NameRequestInfo,
     OfficeAddresses
   }
 })

--- a/tests/unit/DefineCompany.spec.ts
+++ b/tests/unit/DefineCompany.spec.ts
@@ -29,11 +29,6 @@ describe('Define Company component', () => {
   it('renders the component properly', () => {
     // verify page content
     expect(wrapper.find('h2').text()).toContain('Company Name')
-
-    // verify initial button state
-    expect(wrapper.find('#select-bc-btn').attributes('disabled')).toBeUndefined()
-    expect(wrapper.find('#select-cp-btn').attributes('disabled')).toBeUndefined()
-    expect(wrapper.find('#reset-btn').attributes('disabled')).toBe('true')
   })
 
   it('does not display records office in the office address header when entity is a COOP', () => {

--- a/tests/unit/nameRequestInfo.spec.ts
+++ b/tests/unit/nameRequestInfo.spec.ts
@@ -61,41 +61,41 @@ describe('NameRequest Info component', () => {
     const nrListSelector = '#name-request-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
 
-    expect(itemCount).toEqual(6)
+    expect(itemCount).toEqual(5)
+    expect(wrapper.find('#condition-consent').exists()).toBe(false)
 
     const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
     const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
     const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
     const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
     const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
-    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+
     expect(title.textContent).toBeDefined()
     expect(entityType.textContent).toContain('Entity Type:')
     expect(requestType.textContent).toContain('Request Type:')
     expect(expiryDate.textContent).toContain('Expiry Date:')
     expect(status.textContent).toContain('Status:')
-    expect(conditionConsent.textContent).toContain('Condition/Consent:')
   })
 
-  it('renders the Name Request information with no data', () => {
+  it('renders the Name Request information with data', () => {
     wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
     const nrListSelector = '#name-request-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
 
-    expect(itemCount).toEqual(6)
+    expect(itemCount).toEqual(5)
+    expect(wrapper.find('#condition-consent').exists()).toBe(false)
 
     const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
     const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
     const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
     const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
     const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
-    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+
     expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
     expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
     expect(requestType.textContent).toContain('Request Type: New Business')
     expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
     expect(status.textContent).toContain('Status: APPROVED')
-    expect(conditionConsent.textContent).toContain('Condition/Consent: ')
   })
 
   it('renders the Name Request applicant information with data', () => {
@@ -115,7 +115,7 @@ describe('NameRequest Info component', () => {
     expect(phone.textContent).toContain('Phone: 250-356-9090')
   })
 
-  it('renders the Name Request applicant information with data', () => {
+  it('renders the Name Request applicant information with no data', () => {
     const nrListSelector = '#name-request-applicant-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
 
@@ -160,6 +160,7 @@ describe('NameRequest Info component', () => {
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
 
     expect(itemCount).toEqual(6)
+    expect(wrapper.find('#condition-consent').exists()).toBe(true)
 
     const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
     const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
@@ -184,6 +185,7 @@ describe('NameRequest Info component', () => {
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
 
     expect(itemCount).toEqual(6)
+    expect(wrapper.find('#condition-consent').exists()).toBe(true)
 
     const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
     const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]

--- a/tests/unit/nameRequestInfo.spec.ts
+++ b/tests/unit/nameRequestInfo.spec.ts
@@ -1,0 +1,201 @@
+// Libraries
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+
+// Store
+import { store } from '@/store'
+
+// Components
+import { mount } from '@vue/test-utils'
+import { NameRequestInfo } from '@/components/common'
+import { NameRequestStates } from '@/enums'
+
+Vue.use(Vuetify)
+let vuetify = new Vuetify({})
+
+describe('NameRequest Info component', () => {
+  let wrapper: any
+  const mockNrData = {
+    'nrNumber': 'NR 1234567',
+    'entityType': 'BC',
+    'filingId': null,
+    'applicant': {
+      'addressLine1': '45 Frasier Drive',
+      'addressLine2': null,
+      'addressLine3': null,
+      'city': 'Victoria',
+      'countryTypeCode': 'CA',
+      'postalCode': 'V9E 2A1',
+      'stateProvinceCode': 'BC',
+      'emailAddress': 'test@gov.bc.ca',
+      'phoneNumber': '250-356-9090',
+      'firstName': 'John',
+      'middleName': 'Joe',
+      'lastName': 'Doe'
+    },
+    'details': {
+      'approvedName': 'MADRONA BREAD BASKET INC.',
+      'consentFlag': null,
+      'expirationDate': 'Wed, 24 Jun 2020 07:00:00 GMT',
+      'status': 'APPROVED'
+    }
+  }
+
+  beforeEach(() => {
+    wrapper = mount(NameRequestInfo, { vuetify, store })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders name request info labels', () => {
+    expect(wrapper.vm.$el.querySelector('#name-request-info').textContent)
+      .toContain('Name Request')
+
+    expect(wrapper.vm.$el.querySelector('#name-request-applicant-info').textContent)
+      .toContain('Name Request Applicant')
+  })
+
+  it('renders the Name Request information with no data', () => {
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(6)
+
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(title.textContent).toBeDefined()
+    expect(entityType.textContent).toContain('Entity Type:')
+    expect(requestType.textContent).toContain('Request Type:')
+    expect(expiryDate.textContent).toContain('Expiry Date:')
+    expect(status.textContent).toContain('Status:')
+    expect(conditionConsent.textContent).toContain('Condition/Consent:')
+  })
+
+  it('renders the Name Request information with no data', () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(6)
+
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
+    expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
+    expect(requestType.textContent).toContain('Request Type: New Business')
+    expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
+    expect(status.textContent).toContain('Status: APPROVED')
+    expect(conditionConsent.textContent).toContain('Condition/Consent: ')
+  })
+
+  it('renders the Name Request applicant information with data', () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    const nrListSelector = '#name-request-applicant-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(4)
+
+    const name = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const address = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const email = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const phone = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    expect(name.textContent).toContain('Name: John Joe Doe')
+    expect(address.textContent).toContain('Address: 45 Frasier Drive, Victoria, BC, V9E 2A1, Canada')
+    expect(email.textContent).toContain('Email: test@gov.bc.ca')
+    expect(phone.textContent).toContain('Phone: 250-356-9090')
+  })
+
+  it('renders the Name Request applicant information with data', () => {
+    const nrListSelector = '#name-request-applicant-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(4)
+
+    const name = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const address = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const email = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const phone = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    expect(name.textContent).toContain('Name:')
+    expect(address.textContent).toContain('Address:')
+    expect(email.textContent).toContain('Email:')
+    expect(phone.textContent).toContain('Phone:')
+  })
+
+  it('renders the Name Request applicant information with multi address line data', () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    wrapper.vm.$store.state.stateModel.nameRequest.applicant.addressLine1 = 'line 1'
+    wrapper.vm.$store.state.stateModel.nameRequest.applicant.addressLine2 = 'line 2'
+    wrapper.vm.$store.state.stateModel.nameRequest.applicant.addressLine3 = 'line 3'
+    const nrListSelector = '#name-request-applicant-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(4)
+
+    const name = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const address = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const email = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const phone = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    expect(name.textContent).toContain('Name: John Joe Doe')
+    expect(address.textContent).toContain('Address: line 1, line 2, line 3, Victoria, BC, V9E 2A1, Canada')
+    expect(email.textContent).toContain('Email: test@gov.bc.ca')
+    expect(phone.textContent).toContain('Phone: 250-356-9090')
+  })
+
+  it('renders the Name Request information with consent received', () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    wrapper.vm.$store.state.stateModel.nameRequest.details.status = NameRequestStates.CONDITIONAL
+    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = 'R'
+
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(6)
+
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
+    expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
+    expect(requestType.textContent).toContain('Request Type: New Business')
+    expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
+    expect(status.textContent).toContain('Status: CONDITIONAL')
+    expect(conditionConsent.textContent).toContain('Condition/Consent: Received')
+  })
+
+  it('renders the Name Request information with consent not received', () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    wrapper.vm.$store.state.stateModel.nameRequest.details.status = NameRequestStates.CONDITIONAL
+    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = null
+
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+
+    expect(itemCount).toEqual(6)
+
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
+    expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
+    expect(requestType.textContent).toContain('Request Type: New Business')
+    expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
+    expect(status.textContent).toContain('Status: CONDITIONAL')
+    expect(conditionConsent.textContent).toContain('Condition/Consent: Not Received')
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2465

*Description of changes:*
- Add in NameRequestInfo component
- Updated EntityInfo component to use NR Data
- Added helper function to create name request state from NR payload
- Updated review section to use NR Data for the company name
- Added name request data structure interfaces (NR details, NR applicant)
- Added in vuex getters for NR details/applicant, approved name
- Removed BCOMP, COOP, Reset buttons in Name request section in define company and updated tests
- Added Name request info component tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
