### PR TITLE
display errors/warning in case of HTTP 403

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,7 +112,7 @@
 import { Component, Vue, Watch, Mixins } from 'vue-property-decorator'
 import { State, Action, Getter } from 'vuex-class'
 import TokenService from 'sbc-common-components/src/services/token.services'
-import { BAD_REQUEST, PAYMENT_REQUIRED } from 'http-status-codes'
+import { BAD_REQUEST, PAYMENT_REQUIRED, FORBIDDEN } from 'http-status-codes'
 
 // Components
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
@@ -246,6 +246,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
           this.paymentErrorDialog = true
           break
         case BAD_REQUEST:
+        case FORBIDDEN:
           this.saveErrors = error?.response?.data?.errors || []
           this.saveWarnings = error?.response?.data?.warnings || []
           this.saveErrorDialog = true

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -10,7 +10,7 @@ import { DateMixin } from '@/mixins'
 @Component
 export default class NameRequestMixin extends Mixins(DateMixin) {
   /**
-   * Generate name request state for the store
+   * Generates name request state for the store.
    * @param nr the name request response payload
    * @param filingId the filing id
    */
@@ -49,6 +49,7 @@ export default class NameRequestMixin extends Mixins(DateMixin) {
       }
     }
   }
+
   /**
    * Returns True if the Name Request data is valid.
    * @param nr the name request response payload


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2332

*Description of changes:*
While testing the subject ticket in Dev, I found that a response of HTTP 403 (Forbidden) can have useful errors/warning, so I updated the code to handle this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).