### PR TITLE
3608 - handle token refresher failure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -127,7 +127,10 @@ import { AccountAuthorizationDialog, NameRequestInvalidErrorDialog, ConfirmDialo
 import { DateMixin, FilingTemplateMixin, LegalApiMixin, NameRequestMixin } from '@/mixins'
 import { FilingDataIF, ActionBindingIF, ConfirmDialogType } from '@/interfaces'
 import { CertifyStatementResource } from '@/resources'
+
+// Enums and Constants
 import { EntityTypes, FilingCodes, RouteNames, NameRequestStates } from '@/enums'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 @Component({
   components: {
@@ -312,8 +315,21 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
 
       // eslint-disable-next-line no-console
       console.log('Could not initialize token refresher: ', error)
+      this.clearKeycloakSession()
       location.reload()
     }
+  }
+
+  /**
+   * Clears Keycloak token information from session storage
+   */
+  private clearKeycloakSession () : void {
+    sessionStorage.removeItem(SessionStorageKeys.KeyCloakToken)
+    sessionStorage.removeItem(SessionStorageKeys.KeyCloakIdToken)
+    sessionStorage.removeItem(SessionStorageKeys.KeyCloakRefreshToken)
+    sessionStorage.removeItem(SessionStorageKeys.UserFullName)
+    sessionStorage.removeItem(SessionStorageKeys.UserKcId)
+    sessionStorage.removeItem(SessionStorageKeys.UserAccountType)
   }
 
   /** Fetches NR data and fetches draft filing. */

--- a/src/App.vue
+++ b/src/App.vue
@@ -301,11 +301,19 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
     // only initialize once
     // don't start during Jest tests as it messes up the test JWT
     if (this.tokenService || this.isJestRunning) return
+    try {
+      console.info('Starting token refresh service...') // eslint-disable-line no-console
+      this.tokenService = new TokenService()
+      await this.tokenService.init()
+      this.tokenService.scheduleRefreshTimer()
+    } catch (error) {
+      // Happens when the refresh token has expired in session storage
+      // reload to get new tokens
 
-    console.info('Starting token refresh service...') // eslint-disable-line no-console
-    this.tokenService = new TokenService()
-    await this.tokenService.init()
-    this.tokenService.scheduleRefreshTimer()
+      // eslint-disable-next-line no-console
+      console.log('Could not initialize token refresher: ', error)
+      location.reload()
+    }
   }
 
   /** Fetches NR data and fetches draft filing. */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter, { Route } from 'vue-router'
 import { routes } from './routes'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 /**
  * Configures and returns Vue Router.
@@ -47,7 +48,7 @@ export function getVueRouter () {
   /** Returns True if user is authenticated, else False. */
   function isAuthenticated (): boolean {
     // FUTURE: also check that token isn't expired!
-    return Boolean(sessionStorage.getItem('KEYCLOAK_TOKEN'))
+    return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
   }
 
   /** Returns True if route is Signin, else False. */

--- a/src/utils/axios-auth.ts
+++ b/src/utils/axios-auth.ts
@@ -1,10 +1,11 @@
 import axios from 'axios'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 const instance = axios.create()
 
 instance.interceptors.request.use(
   config => {
-    config.headers.common['Authorization'] = `Bearer ${sessionStorage.getItem('KEYCLOAK_TOKEN')}`
+    config.headers.common['Authorization'] = `Bearer ${sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)}`
     return config
   },
   error => Promise.reject(error)

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,7 +10,7 @@ module.exports = {
     proxy: {
       // this is needed to prevent a CORS error when running locally
       '/local-keycloak-config-url/*': {
-        target: 'https://dev.bcregistry.ca/cooperatives/auth/config/kc/',
+        target: 'https://business-create-dev.pathfinder.gov.bc.ca/businesses/create/config/kc/',
         pathRewrite: {
           '/local-keycloak-config-url': ''
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3608

*Description of changes:*
- added logic to catch error for token refresher failure and refresh the page ( an error is thrown if the refresh token has expired)
- updated keycloak config proxy url for local dev

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
