### PR TITLE
improved address UX re: country and province

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bcrs-business-create-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15271,9 +15271,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.1.27.tgz",
-      "integrity": "sha512-8C8nhGNG7zXUbVBh6RDkee8yqlViVKsMhZPOfULhGgycbWAXUqaxNuz9wVvbGobbeBTRao68GR4+vWg1KkRD9w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.1.29.tgz",
+      "integrity": "sha512-ABkJ6prd2a7Fo0FeQ4f5LVR1N62jKAnbgbnWFRBY0msWeTQORMMvKNOUNOS6lO92aWDM0Q6K6Rs6oF/FKzIU4g==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.18.0",
@@ -17398,9 +17398,9 @@
       "dev": true
     },
     "vue-i18n": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.17.4.tgz",
-      "integrity": "sha512-wpk/drIkPf6gHCtvHc8zAZ1nsWBZ+/OOJYtJxqhYD6CKT0FJAG5oypwgF9kABt30FBWhl8NEb/QY+vaaBARlFg=="
+      "version": "8.17.6",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.17.6.tgz",
+      "integrity": "sha512-SsKL5D9Ii3zJPsFhUSllY754XuZvP8uCouUm+Mbylu95h3OwenV09uzIIEjkT7EtWyDQuWSMWObrNaD4ukBGZw=="
     },
     "vue-jest": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcrs-business-create-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -20,7 +20,7 @@
     "launchdarkly-js-client-sdk": "^2.17.0",
     "lodash": "^4.17.15",
     "regenerator-runtime": "^0.13.3",
-    "sbc-common-components": "2.1.27",
+    "sbc-common-components": "2.1.29",
     "vue": "^2.6.11",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.1.6",

--- a/src/App.vue
+++ b/src/App.vue
@@ -225,7 +225,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   }
 
   /** Helper to check is the current route matches */
-  private isRouteName (routeName: string) : boolean {
+  private isRouteName (routeName: string): boolean {
     return this.$route.name === routeName
   }
 
@@ -324,7 +324,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   /**
    * Clears Keycloak token information from session storage
    */
-  private clearKeycloakSession () : void {
+  private clearKeycloakSession (): void {
     sessionStorage.removeItem(SessionStorageKeys.KeyCloakToken)
     sessionStorage.removeItem(SessionStorageKeys.KeyCloakIdToken)
     sessionStorage.removeItem(SessionStorageKeys.KeyCloakRefreshToken)

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -193,13 +193,13 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
   private addPersonOrgFormValid: boolean = true
 
   // Address related properties
-  private inProgressMailingAddress:AddressIF
-  private inProgressDeliveryAddress:AddressIF
+  private inProgressMailingAddress: AddressIF
+  private inProgressDeliveryAddress: AddressIF
   private inheritMailingAddress: boolean = true
   private personAddressSchema: {} = personAddressSchema
   private mailingAddressValid: boolean = false
   private deliveryAddressValid: boolean = false
-  private reassignCompletingParty : boolean = false
+  private reassignCompletingParty: boolean = false
 
   // Roles
   private isCompletingParty: boolean = false
@@ -290,7 +290,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     }
   }
 
-  private isFormValid () : boolean {
+  private isFormValid (): boolean {
     let isFormValid: boolean = this.addPersonOrgFormValid && this.mailingAddressValid
     if (this.isDirector && !this.inheritMailingAddress) {
       isFormValid = isFormValid && this.deliveryAddressValid
@@ -366,7 +366,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     }
   }
 
-  private isRoleLocked (role: Roles) : boolean {
+  private isRoleLocked (role: Roles): boolean {
     return this.orgPerson.roles.some(party => party.roleType === role) && this.activeIndex === -1
   }
 
@@ -374,7 +374,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     this.emitRemovePersonEvent(this.activeIndex)
   }
 
-  private reassignPersonErrorMessage () : string {
+  private reassignPersonErrorMessage (): string {
     let errorMessage: string =
     `<p>The Completing Party role is already assigned to ${this.existingCompletingParty.officer.firstName}
      ${this.existingCompletingParty.officer.middleName || ''} ${this.existingCompletingParty.officer.lastName}.</p>
@@ -390,7 +390,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
     return this.orgPerson.officer?.partyType === IncorporatorTypes.CORPORATION
   }
 
-  get incorporatorLabel () : string {
+  get incorporatorLabel (): string {
     return this.entityFilter(EntityTypes.BCOMP) ? Roles.INCORPORATOR : Roles.SUBSCRIBER
   }
 
@@ -405,7 +405,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
   private emitRemovePersonEvent (activeIndex: Number): void { }
 
   @Emit('removeCompletingPartyRole')
-  private emitReassignCompletingPartyEvent () : void {}
+  private emitReassignCompletingPartyEvent (): void {}
 }
 </script>
 

--- a/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/PeopleAndRoles.vue
@@ -22,53 +22,60 @@
         <span class='chk-list-item-txt'>At least one Director</span>
       </li>
     </ul>
+
     <div class="btn-panel" v-if="orgPersonList.length === 0">
       <v-btn outlined color="primary"
-      @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
-      :disabled="showOrgPersonForm" id="btn-start-add-cp">
+        @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
+        :disabled="showOrgPersonForm" id="btn-start-add-cp"
+      >
         <v-icon>mdi-account-plus-outline</v-icon>
         <span>Start by Adding the Completing Party</span>
       </v-btn>
     </div>
+
     <div class="btn-panel"  v-if="orgPersonList.length > 0">
       <v-btn outlined color="primary" @click="addOrgPerson([], IncorporatorTypes.PERSON)"
-      :disabled="showOrgPersonForm" id="btn-add-person">
+        :disabled="showOrgPersonForm" id="btn-add-person"
+      >
         <v-icon>mdi-account-plus</v-icon>
         <span>Add a Person</span>
       </v-btn>
       <v-btn outlined color="primary" :disabled="showOrgPersonForm" class="spacedButton"
-      @click="addOrgPerson([{ roleType: Roles.INCORPORATOR }], IncorporatorTypes.CORPORATION)" id="btn-add-corp">
+        @click="addOrgPerson([{ roleType: Roles.INCORPORATOR }], IncorporatorTypes.CORPORATION)" id="btn-add-corp"
+      >
         <v-icon>mdi-domain-plus</v-icon>
         <span v-if="entityFilter(EntityTypes.BCOMP)">Add a Corporation or Firm</span>
         <span v-if="entityFilter(EntityTypes.COOP)">Add Organization</span>
       </v-btn>
       <v-btn outlined color="primary"
-      @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
-      :disabled="showOrgPersonForm"  class="spacedButton" v-if="!hasRole(Roles.COMPLETING_PARTY, 1, 'ATLEAST')"
-      id="btn-add-cp">
+        @click="addOrgPerson([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
+        :disabled="showOrgPersonForm"  class="spacedButton" v-if="!hasRole(Roles.COMPLETING_PARTY, 1, 'ATLEAST')"
+        id="btn-add-cp"
+      >
         <v-icon>mdi-account-plus-outline</v-icon>
         <span>Add the Completing Party</span>
       </v-btn>
     </div>
+
     <v-card flat class="people-roles-container" v-if="showOrgPersonForm">
       <OrgPerson v-show="showOrgPersonForm"
-      :initialValue="currentOrgPerson"
-      :activeIndex="activeIndex"
-      :nextId="nextId"
-      :existingCompletingParty="completingParty"
-      @addEditPerson="onAddEditOrgPerson($event)"
-      @removePersonEvent="onRemovePerson($event)"
-      @resetEvent="resetData()"
-      @removeCompletingPartyRole="removeCompletingPartyAssignment()" />
+        :initialValue="currentOrgPerson"
+        :activeIndex="activeIndex"
+        :nextId="nextId"
+        :existingCompletingParty="completingParty"
+        @addEditPerson="onAddEditOrgPerson($event)"
+        @removePersonEvent="onRemovePerson($event)"
+        @resetEvent="resetData()"
+        @removeCompletingPartyRole="removeCompletingPartyAssignment()" />
     </v-card>
 
     <v-card flat v-if="orgPersonList.length > 0" :disabled="showOrgPersonForm" >
       <ListPeopleAndRoles
-        v-if="orgPersonList.length > 0"
-        :personList="orgPersonList"
-        :isSummary="false"
-        @editPerson="editOrgPerson($event)"
-        @removePerson="onRemovePerson($event)"/>
+          v-if="orgPersonList.length > 0"
+          :personList="orgPersonList"
+          :isSummary="false"
+          @editPerson="editOrgPerson($event)"
+          @removePerson="onRemovePerson($event)" />
     </v-card>
   </div>
 </template>
@@ -79,7 +86,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { Action, State } from 'vuex-class'
 
 // Interfaces
-import { ActionBindingIF, BaseAddressType, FormType, OrgPersonIF, RolesIF } from '@/interfaces'
+import { ActionBindingIF, OrgPersonIF, RolesIF } from '@/interfaces'
 
 // Mixins
 import { EntityFilterMixin } from '@/mixins'
@@ -98,13 +105,7 @@ import ListPeopleAndRoles from './ListPeopleAndRoles.vue'
   }
 })
 export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
-   $refs!: {
-    addPersonForm: FormType,
-    mailingAddressNew: BaseAddressType,
-    deliveryAddressNew: BaseAddressType
-  }
-
-   // State
+  // State
   @State(state => state.stateModel.addPeopleAndRoleStep.orgPeople)
   readonly orgPersonList: OrgPersonIF[]
 
@@ -158,7 +159,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
     this.showOrgPersonForm = true
   }
 
-  private editOrgPerson (index: number) : void {
+  private editOrgPerson (index: number): void {
     this.currentOrgPerson = { ...this.orgPersonList[index] }
     this.activeIndex = index
     this.addEditInProgress = true
@@ -179,8 +180,8 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
     this.resetData()
   }
 
-  private onRemovePerson (index: number) : void {
-    let newList: OrgPersonIF[] = Object.assign([], this.orgPersonList)
+  private onRemovePerson (index: number): void {
+    const newList: OrgPersonIF[] = Object.assign([], this.orgPersonList)
     newList.splice(index, 1)
     this.setOrgPersonList(newList)
     this.setAddPeopleAndRoleStepValidity(this.hasValidRoles())
@@ -188,10 +189,10 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
   }
 
   private removeCompletingPartyAssignment () {
-    let newList: OrgPersonIF[] = Object.assign([], this.orgPersonList)
+    const newList: OrgPersonIF[] = Object.assign([], this.orgPersonList)
     const cpList = newList.filter(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY))
     if (cpList.length > 0) {
-      let completingParty : OrgPersonIF = cpList[0]
+      const completingParty: OrgPersonIF = cpList[0]
       completingParty.roles = completingParty.roles.filter(party => party.roleType !== Roles.COMPLETING_PARTY)
       this.setOrgPersonList(newList)
     }
@@ -204,15 +205,15 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
     this.showOrgPersonForm = false
   }
 
-  private hasValidRoles () : boolean {
+  private hasValidRoles (): boolean {
     const numOfDirector: number =
-    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.DIRECTOR)).length
+      this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.DIRECTOR)).length
     const numOfIncorporator: number =
-    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.INCORPORATOR)).length
+      this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.INCORPORATOR)).length
     const numOfCompletingParty: number =
-    this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY)).length
-    const numOfPeopleWithNoRoles:number =
-    this.orgPersonList.filter(people => people.roles.length === 0).length
+      this.orgPersonList.filter(people => people.roles.some(party => party.roleType === Roles.COMPLETING_PARTY)).length
+    const numOfPeopleWithNoRoles: number =
+      this.orgPersonList.filter(people => people.roles.length === 0).length
 
     if (this.entityFilter(EntityTypes.BCOMP)) {
       return numOfCompletingParty === 1 && numOfIncorporator >= 1 && numOfDirector >= 1 && numOfPeopleWithNoRoles === 0
@@ -221,7 +222,7 @@ export default class PeopleAndRoles extends Mixins(EntityFilterMixin) {
     }
   }
 
-  private hasRole (roleName: Roles, count:number, mode:string) : boolean {
+  private hasRole (roleName: Roles, count: number, mode: string): boolean {
     const orgPersonWithSpecifiedRole: OrgPersonIF[] =
     this.orgPersonList.filter(people => people.roles.some(party => party.roleType === roleName))
 

--- a/src/components/CreateShareStructure/ShareStructure.vue
+++ b/src/components/CreateShareStructure/ShareStructure.vue
@@ -299,13 +299,13 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
     }
   }
 
-  private changeMaximumShareFlag () {
+  private changeMaximumShareFlag (): void {
     if (this.hasNoMaximumShares) {
       this.shareStructure.maxNumberOfShares = null
     }
   }
 
-  private changeParValueFlag () {
+  private changeParValueFlag (): void {
     if (this.hasNoParValue) {
       this.shareStructure.currency = null
       this.shareStructure.parValue = null
@@ -321,7 +321,7 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
     return this.shareStructure.type === 'Series'
   }
 
-  get isNoMaxSharesVisible () : boolean {
+  get isNoMaxSharesVisible (): boolean {
     return this.isSeries ? !(this.shareClasses[this.parentIndex].hasMaximumShares) : true
   }
 
@@ -336,7 +336,7 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
   private emitRemoveShareClassEvent (shareClassIndex: number): void {}
 
   @Emit('removeSeries')
-  private emitRemoveShareSeriesEvent (parentIndex:number, shareSeriesIndex: number): void {}
+  private emitRemoveShareSeriesEvent (parentIndex: number, shareSeriesIndex: number): void {}
 
   @Emit('resetEvent')
   private emitResetEvent (): void {}

--- a/src/components/DefineCompany/BusinessContactInfo.vue
+++ b/src/components/DefineCompany/BusinessContactInfo.vue
@@ -100,7 +100,7 @@ export default class BusinessContactInfo extends Vue {
   // Properties
   private contact: BusinessContactIF = this.initialValue
 
-  private formValid : boolean = false
+  private formValid: boolean = false
 
   // Rules
   private emailRules = [
@@ -138,16 +138,16 @@ export default class BusinessContactInfo extends Vue {
   }
 
   @Watch('formValid')
-  private onFormValidityChange (val:boolean): void{
+  private onFormValidityChange (val: boolean): void {
     this.emitContactFormState(val)
   }
 
   // Events
   @Emit('contactInfoChange')
-  private emitContactInfo (contactInfo : BusinessContactIF): void { }
+  private emitContactInfo (contactInfo: BusinessContactIF): void { }
 
   @Emit('contactInfoFormValidityChange')
-  private emitContactFormState (validity : boolean): void {}
+  private emitContactFormState (validity: boolean): void { }
 }
 </script>
 

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -45,7 +45,7 @@ import { Getter } from 'vuex-class'
 // Interfaces
 import { GetterIF } from '@/interfaces'
 
-@Component
+@Component({})
 export default class EntityInfo extends Vue {
   // Global getters
   @Getter isEntityType!: GetterIF

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -54,7 +54,7 @@ import { GetterIF, NameRequestDetailsIF, NameRequestApplicantIF } from '@/interf
 // Mixins
 import { DateMixin } from '@/mixins'
 
-@Component
+@Component({})
 export default class NameRequestInfo extends Mixins(DateMixin) {
   // Template Enums
   readonly NameRequestStates = NameRequestStates
@@ -68,7 +68,7 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   @Getter getNameRequestApplicant!: NameRequestApplicantIF;
 
   /** The entity title  */
-  private entityTypeDescription () :string {
+  private entityTypeDescription (): string {
     if (this.isTypeBcomp) {
       return 'BC Benefit Company'
     } else if (this.isTypeCoop) {
@@ -79,12 +79,12 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** The request type */
-  private requestType () : string {
+  private requestType (): string {
     return 'New Business'
   }
 
   /** Return formatted expiration date */
-  private formattedExpirationDate () : string {
+  private formattedExpirationDate (): string {
     return this.toReadableDate(this.getNameRequestDetails.expirationDate)
   }
 
@@ -98,7 +98,7 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** Return formatted applicant name */
-  private applicantName () : string {
+  private applicantName (): string {
     let name = this.getNameRequestApplicant.firstName
     if (this.getNameRequestApplicant.middleName) {
       name = `${name} ${this.getNameRequestApplicant.middleName} ${this.getNameRequestApplicant.lastName}`
@@ -109,7 +109,7 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   }
 
   /** Return formatted address string */
-  private applicantAddress () : string {
+  private applicantAddress (): string {
     // Get Address info
     const city = this.getNameRequestApplicant.city
     const stateProvince = this.getNameRequestApplicant.stateProvinceCode

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -27,7 +27,7 @@ import { Getter } from 'vuex-class'
 // Interfaces
 import { GetterIF } from '@/interfaces'
 
-@Component
+@Component({})
 export default class Stepper extends Vue {
   @Getter getSteps!: GetterIF
 }

--- a/src/components/dialogs/ConfimRemoveDialog.vue
+++ b/src/components/dialogs/ConfimRemoveDialog.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 
-@Component
+@Component({})
 export default class ConfirmRemoveDialog extends Vue {
   // Prop to display the dialog.
   @Prop() private dialog: boolean

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/add-people-role-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/add-people-role-interface.ts
@@ -2,5 +2,5 @@ import { OrgPersonIF } from '@/interfaces'
 
 export interface PeopleAndRoleIF {
     valid: boolean
-    orgPeople : OrgPersonIF[]
+    orgPeople: OrgPersonIF[]
 }

--- a/src/interfaces/stepper-interfaces/CreateShareStructure/create-share-structure-interface.ts
+++ b/src/interfaces/stepper-interfaces/CreateShareStructure/create-share-structure-interface.ts
@@ -1,10 +1,10 @@
 export interface ShareStructureIF {
     valid: boolean;
-    shareClasses : ShareClassIF[];
+    shareClasses: ShareClassIF[];
 }
 
 export interface ShareClassIF {
-    id: number| null;
+    id: number | null;
     type?: string; // Indicates whether class or series
     name: string;
     priority: number;

--- a/src/interfaces/stepper-interfaces/DefineCompany/address-interface.ts
+++ b/src/interfaces/stepper-interfaces/DefineCompany/address-interface.ts
@@ -1,23 +1,28 @@
+/** Interface to define a base address. */
 export interface AddressIF {
-    addressCity: string;
-    addressCountry: string;
-    addressRegion: string;
-    deliveryInstructions?: string;
-    postalCode: string;
-    streetAddress: string;
-    streetAddressAdditional?: string;
-  }
+  addressCity: string;
+  addressCountry: string;
+  addressRegion: string;
+  deliveryInstructions?: string;
+  postalCode: string;
+  streetAddress: string;
+  streetAddressAdditional?: string;
+}
 
-// Interface to define the joint base address response
+/** Interface to define the joint base addresses. */
 export interface BaseAddressObjIF {
-    deliveryAddress?: AddressIF;
-    mailingAddress: AddressIF;
-  }
+  mailingAddress: AddressIF;
+  // Delivery Address is required for completing party and offices.
+  // Delivery Address is optional for completing party and incorporators.
+  deliveryAddress?: AddressIF;
+}
 
-// Interface to define the Bcorps address response
+/** Interface to define the incorporation addresses. */
 export interface IncorporationAddressIf {
-    registeredOffice: BaseAddressObjIF;
-    recordsOffice?: BaseAddressObjIF;
+  registeredOffice: BaseAddressObjIF;
+  // Records Address is required for BCOMPs.
+  // Records Address may be optional for other app types.
+  recordsOffice?: BaseAddressObjIF;
 }
 
 export interface BaseAddressType extends Vue {

--- a/src/interfaces/stepper-interfaces/DefineCompany/define-company-interface.ts
+++ b/src/interfaces/stepper-interfaces/DefineCompany/define-company-interface.ts
@@ -1,7 +1,7 @@
-import { BusinessContactIF, NameRequestIF, IncorporationAddressIf } from '@/interfaces'
+import { BusinessContactIF, IncorporationAddressIf } from '@/interfaces'
 
 export interface DefineCompanyIF {
     valid: boolean
-    businessContact : BusinessContactIF,
-    officeAddresses : IncorporationAddressIf | {}
+    businessContact: BusinessContactIF
+    officeAddresses: IncorporationAddressIf | {}
 }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -4,7 +4,7 @@ import { omit, isEqual } from 'lodash'
 /**
  * Mixin that provides some useful common utilities.
  */
-@Component
+@Component({})
 export default class CommonMixin extends Vue {
   /**
    * This is an example mixin that will return a msg.

--- a/src/mixins/currency-lookup-mixin.ts
+++ b/src/mixins/currency-lookup-mixin.ts
@@ -169,7 +169,7 @@ export default class CurrencyLookupMixin extends Vue {
     return this.currencyList
   }
 
-  getCurrencyNameByCode (code : string) : string | null {
+  getCurrencyNameByCode (code: string): string | null {
     const currency = this.currencyList.find(currency => currency.code === code)
     return currency?.name
   }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -3,8 +3,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import { State, Getter, Action } from 'vuex-class'
 
 // Interfaces
-import { ActionBindingIF, StateModelIF, IncorporationFilingIF, GetterIF,
-  NameRequestDetailsIF } from '@/interfaces'
+import { ActionBindingIF, StateModelIF, IncorporationFilingIF, GetterIF } from '@/interfaces'
 
 // Constants
 import { INCORPORATION_APPLICATION } from '@/constants'
@@ -12,16 +11,16 @@ import { INCORPORATION_APPLICATION } from '@/constants'
 /**
  * Mixin that provides the integration with the legal api.
  */
-@Component
+@Component({})
 export default class FilingTemplateMixin extends Vue {
-  // Global state
+  // Global State
   @State stateModel!: StateModelIF
 
   // Global Getters
   @Getter isTypeBcomp!: GetterIF
   @Getter getApprovedName!: string
 
-  // Global actions
+  // Global Actions
   @Action setEntityType!: ActionBindingIF
   @Action setBusinessContact!: ActionBindingIF
   @Action setOfficeAddresses!: ActionBindingIF
@@ -34,9 +33,7 @@ export default class FilingTemplateMixin extends Vue {
   @Action setEffectiveDate!: ActionBindingIF
   @Action setIsFutureEffective!: ActionBindingIF
 
-  /**
-   * Method to construct a filing body when making an api request
-   */
+  /** Constructs a filing body, used when saving a filing. */
   buildFiling (): IncorporationFilingIF {
     // Format DateTime for Filing
     const effectiveDate = this.stateModel.incorporationDateTime.effectiveDate
@@ -77,8 +74,8 @@ export default class FilingTemplateMixin extends Vue {
   }
 
   /**
-   * Method to parse a received draft filing into the store
-   * @param draftFiling The draft filing body to be parsed and assigned to store
+   * Parses a fetched draft filing into the store.
+   * @param draftFiling the draft filing body to be parsed
    */
   parseDraft (draftFiling: any): void {
     // Set Office Addresses

--- a/src/mixins/legal-api-mixin.ts
+++ b/src/mixins/legal-api-mixin.ts
@@ -10,7 +10,7 @@ import { StateModelIF, ActionBindingIF, GetterIF, IncorporationFilingIF } from '
 /**
  * Mixin that provides the integration with the legal api.
  */
-@Component
+@Component({})
 export default class LegalApiMixin extends Vue {
   readonly NAME_REQUEST = 'nameRequest'
   readonly INCORPORATION_APPLICATION = 'incorporationApplication'

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -7,7 +7,7 @@ import { DateMixin } from '@/mixins'
 /**
  * Name request mixin for processing NR responses
  */
-@Component
+@Component({})
 export default class NameRequestMixin extends Mixins(DateMixin) {
   /**
    * Generates name request state for the store.

--- a/src/schemas/office-address-schema.ts
+++ b/src/schemas/office-address-schema.ts
@@ -1,4 +1,5 @@
 import { required, maxLength } from 'vuelidate/lib/validators'
+
 // The Address schema containing Vuelidate rules.
 // NB: This should match the subject JSON schema.
 export const officeAddressSchema = {
@@ -16,12 +17,12 @@ export const officeAddressSchema = {
   addressCountry: {
     required,
     // FUTURE: create new validation function isCountry('CA')
-    isCanada: (val:string) => Boolean(val === 'CA')
+    isCanada: (val: string) => Boolean(val === 'CA')
   },
   addressRegion: {
     maxLength: maxLength(2),
     // FUTURE: create new validation function isRegion('BC')
-    isBC: (val:string) => Boolean(val === 'BC')
+    isBC: (val: string) => Boolean(val === 'BC')
   },
   postalCode: {
     required,

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -1,4 +1,4 @@
-import { StateModelIF, NameRequestApplicantIF, NameRequestDetailsIF } from '@/interfaces'
+import { StateModelIF } from '@/interfaces'
 
 export const stateModel: StateModelIF = {
   tombstone: {
@@ -8,9 +8,9 @@ export const stateModel: StateModelIF = {
   nameRequest: {
     nrNumber: '',
     entityType: '',
-    details: {} as NameRequestDetailsIF,
-    applicant: {} as NameRequestApplicantIF,
-    filingId: null as number
+    details: {},
+    applicant: {},
+    filingId: null
   },
   currentDate: '',
   incorporationDateTime: {

--- a/src/views/CreateShareStructure.vue
+++ b/src/views/CreateShareStructure.vue
@@ -285,7 +285,7 @@ export default class CreateShareStructure extends Vue {
     return Boolean(this.$route.query.showErrors)
   }
 
-  private get helpLink () : string {
+  private get helpLink (): string {
     return 'https://www2.gov.bc.ca/gov/content/employment-business/business/' +
     'managing-a-business/permits-licences/businesses-incorporated-companies'
   }

--- a/src/views/DefineCompany.vue
+++ b/src/views/DefineCompany.vue
@@ -48,7 +48,7 @@ import { Component, Mixins, Vue } from 'vue-property-decorator'
 import { Getter, Action, State } from 'vuex-class'
 
 // Interfaces
-import { GetterIF, ActionBindingIF, BusinessContactIF, IncorporationAddressIf } from '@/interfaces'
+import { GetterIF, ActionBindingIF, BusinessContactIF, IncorporationAddressIf, AddressIF } from '@/interfaces'
 
 // Mixins
 import { EntityFilterMixin } from '@/mixins'
@@ -93,16 +93,51 @@ export default class DefineCompany extends Mixins(EntityFilterMixin) {
 
   /** Called when component is created. */
   private created (): void {
-    // ignore data changes until page has loaded
+    // temporarily ignore data changes
     this.setIgnoreChanges(true)
+
+    // if no addresses were fetched, set default addresses
+    if (!this.addresses.registeredOffice && !this.addresses.recordsOffice) {
+      this.setDefaultAddresses()
+    }
+
+    // watch data changes once page has loaded (in next tick)
     Vue.nextTick(() => {
       this.setIgnoreChanges(false)
     })
   }
 
-  private mounted () {
-    // always false initially
-    // this.setDefineCompanyStepValidity(this.businessContactFormValid && this.addressFormValid)
+  /** Sets default addresses in filing. (Will get overwritten by a fetched draft filing if there is one.) */
+  private setDefaultAddresses (): void {
+    const defaultAddress: AddressIF = {
+      addressCity: '',
+      addressCountry: 'CA',
+      addressRegion: 'BC',
+      deliveryInstructions: '',
+      postalCode: '',
+      streetAddress: '',
+      streetAddressAdditional: ''
+    }
+
+    if (this.entityFilter(EntityTypes.BCOMP)) {
+      this.setOfficeAddresses({
+        registeredOffice: {
+          mailingAddress: defaultAddress,
+          deliveryAddress: defaultAddress
+        },
+        recordsOffice: {
+          mailingAddress: defaultAddress,
+          deliveryAddress: defaultAddress
+        }
+      })
+    } else {
+      this.setOfficeAddresses({
+        registeredOffice: {
+          mailingAddress: defaultAddress,
+          deliveryAddress: defaultAddress
+        }
+      })
+    }
   }
 
   private onBusinessContactInfoChange (businessContact: BusinessContactIF): void {

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -45,15 +45,9 @@ describe('Actions component', () => {
       certifiedBy: 'Some certifier'
     }
     store.state.stateModel.nameRequest = { entityType: 'BC' }
-    store.state.stateModel.defineCompanyStep = {
-      valid: true
-    }
-    store.state.stateModel.addPeopleAndRoleStep = {
-      valid: true
-    }
-    store.state.stateModel.incorporationDateTime = {
-      valid: true
-    }
+    store.state.stateModel.defineCompanyStep = { valid: true }
+    store.state.stateModel.addPeopleAndRoleStep = { valid: true }
+    store.state.stateModel.incorporationDateTime = { valid: true }
     await Vue.nextTick(() => {
       // verify File and Pay button state
       expect(wrapper.find('#file-pay-btn').attributes('disabled')).toBeUndefined()
@@ -259,7 +253,10 @@ describe('Actions component - Filing Functionality', () => {
     const router = mockRouter.mock()
     router.push({ name: 'define-company', query: { nrNumber: 'NR 1234567' } })
     wrapper = shallowMount(Actions, { localVue, store, router, vuetify })
+
+    // Mock the function calls that may used by saveFiling below
     jest.spyOn(wrapper.vm, 'createFiling').mockImplementation()
+    jest.spyOn(wrapper.vm, 'updateFiling').mockImplementation()
   })
 
   afterEach(() => {
@@ -325,27 +322,15 @@ describe('Actions component - Filing Functionality', () => {
     expect(events.length).toBe(1)
   })
 
-  it('Calls the buildFiling method when onClickFilePay is called', async () => {
+  it('Calls the buildFiling and saveFiling methods when onClickFilePay is called', async () => {
     const mockBuildFiling = jest.spyOn(wrapper.vm, 'buildFiling')
     const mockSaveFiling = jest.spyOn(wrapper.vm, 'saveFiling')
-      .mockImplementation(() => Promise.resolve({ header: { paymentToken: 789 } })) // required for save
+      .mockImplementation(() => Promise.resolve({ header: { paymentToken: 789 } }))
 
     await wrapper.vm.onClickFilePay()
 
     expect(mockBuildFiling).toHaveBeenCalled()
     expect(mockBuildFiling).toHaveReturned()
-
-    // verify redirection
-    const baseUrl = 'myhost/basePath/auth/makepayment/789/myhost%2Fcooperatives%2FNR%201234567'
-
-    expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
-  })
-
-  it('Calls the saveFiling method with the correct filing structure when onClickFilePay is called', async () => {
-    const mockSaveFiling = jest.spyOn(wrapper.vm, 'saveFiling')
-      .mockImplementation(() => Promise.resolve({ header: { paymentToken: 789 } }))
-
-    await wrapper.vm.onClickFilePay()
 
     expect(mockSaveFiling).toHaveBeenCalledWith(filing, false)
     expect(mockSaveFiling).toHaveReturned()

--- a/tests/unit/DefineCompany.spec.ts
+++ b/tests/unit/DefineCompany.spec.ts
@@ -19,32 +19,59 @@ localVue.use(VueRouter)
 const router = mockRouter.mock()
 
 describe('Define Company view', () => {
-  let wrapper: any
+  it('renders the component properly', () => {
+    const wrapper = shallowMount(DefineCompany, { localVue, store, router, vuetify })
 
-  beforeEach(() => {
-    wrapper = shallowMount(DefineCompany, { localVue, store, router, vuetify })
-  })
+    // verify page content
+    expect(wrapper.find('h2').text()).toContain('Company Name')
 
-  afterEach(() => {
+    // ensure there are no saved addresses to interfere with other tests
+    const addresses = store.state.stateModel.defineCompanyStep.officeAddresses
+    delete addresses.registeredOffice
+    delete addresses.recordsOffice
+
     wrapper.destroy()
   })
 
-  it('renders the component properly', () => {
-    // verify page content
-    expect(wrapper.find('h2').text()).toContain('Company Name')
-  })
-
-  it('does not display records office in the office address header when entity is a COOP', () => {
+  it('doesn\'t display records office in the office address header when entity is a COOP', () => {
     store.state.stateModel.nameRequest.entityType = 'CP'
+    const wrapper = shallowMount(DefineCompany, { localVue, store, router, vuetify })
 
     expect(wrapper.vm.$el.querySelector('#office-address-header').textContent).not.toContain('Records')
+
+    // verify default addresses
+    const addresses = store.state.stateModel.defineCompanyStep.officeAddresses
+    expect(addresses.registeredOffice.mailingAddress.addressCountry).toBe('CA')
+    expect(addresses.registeredOffice.mailingAddress.addressRegion).toBe('BC')
+    expect(addresses.registeredOffice.deliveryAddress.addressCountry).toBe('CA')
+    expect(addresses.registeredOffice.deliveryAddress.addressRegion).toBe('BC')
+    expect(addresses.recordsOffice).toBeUndefined()
+
+    // ensure there are no saved addresses to interfere with other tests
+    delete addresses.registeredOffice
+    delete addresses.recordsOffice
+
+    wrapper.destroy()
   })
 
-  it('does display records office in the office address header when entity is a BCOMP', async () => {
+  it('displays records office in the office address header when entity is a BCOMP', () => {
     store.state.stateModel.nameRequest.entityType = 'BC'
+    const wrapper = shallowMount(DefineCompany, { localVue, store, router, vuetify })
 
-    await Vue.nextTick(() => {
-      expect(wrapper.vm.$el.querySelector('#office-address-header').textContent).toContain('Records')
-    })
+    expect(wrapper.vm.$el.querySelector('#office-address-header').textContent).toContain('Records')
+
+    // verify default addresses
+    const addresses = store.state.stateModel.defineCompanyStep.officeAddresses
+    expect(addresses.registeredOffice).not.toBeUndefined()
+    expect(addresses.recordsOffice.mailingAddress.addressCountry).toBe('CA')
+    expect(addresses.recordsOffice.mailingAddress.addressRegion).toBe('BC')
+    expect(addresses.recordsOffice.deliveryAddress.addressCountry).toBe('CA')
+    expect(addresses.recordsOffice.deliveryAddress.addressRegion).toBe('BC')
+
+    // ensure there are no saved addresses to interfere with other tests
+    delete addresses.registeredOffice
+    delete addresses.recordsOffice
+
+    wrapper.destroy()
   })
 })

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -38,7 +38,7 @@ function resetStore (): void {
   store.state.stateModel.addPeopleAndRoleStep.orgPeople = []
 }
 
-function getPersonList (roles = [completingPartyRole]) : any {
+function getPersonList (roles = [completingPartyRole]): any {
   const mockPersonList = [
     {
       'officer': {

--- a/tests/unit/ReviewConfirm.spec.ts
+++ b/tests/unit/ReviewConfirm.spec.ts
@@ -18,14 +18,12 @@ const store = getVuexStore()
 
 describe('Review Confirm view', () => {
   let wrapper: any
-  let vm: any
 
   beforeEach(() => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     wrapper = shallowMount(ReviewConfirm, { localVue, store, router, vuetify })
-    vm = wrapper.vm as any
   })
 
   afterEach(() => {

--- a/tests/unit/ShareStructure.spec.ts
+++ b/tests/unit/ShareStructure.spec.ts
@@ -83,8 +83,9 @@ function createShareStructure (
   hasParValue = true,
   parValue = null,
   currency = null,
-  hasRightsOrRestrictions = false) : ShareClassIF {
-  const shareStructure : ShareClassIF = {
+  hasRightsOrRestrictions = false
+): ShareClassIF {
+  const shareStructure: ShareClassIF = {
     id: id,
     priority: priority,
     type: type,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3477

*Description of changes:*
- updated app version to 0.4.0
- updated sbc-common-components import to 2.1.29 (non-readonly address
fields)
- cleaned up spaces around types
- cleaned up some indentations
- deleted obsolete imports, $refs, etc
- changed some divs to templates
- added missing case in updateAddress() that caused console logs
- added misc comments
- deleted redundant types in stateModel
- added method to set default address (country and region)
- updated misc unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).