### PR TITLE
3764 - work around for user settings call

### DIFF
--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -4,6 +4,7 @@
   "DASHBOARD_URL": "https://dev.bcregistry.ca/cooperatives/",
   "LEGAL_API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1/",
+  "SBC_CONFIG_AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1",
   "PAY_API_URL": "https://pay-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "KEYCLOAK_CONFIG_PATH": "/local-keycloak-config-url/keycloak.json",
   "ADDRESS_COMPLETE_KEY": "RH99-RN99-GB72-FW86",

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -39,6 +39,17 @@ export async function fetchConfig (): Promise<any> {
     return Promise.reject(new Error('Could not fetch configuration.json'))
   })
 
+  /**
+   * authConfig is a workaround to fix the user settings call as it expects a URL with no trailing slash.
+   * This will be removed when a fix is made to sbc-common-components to handle this
+   */
+  const authConfig = {
+    'VUE_APP_AUTH_ROOT_API': response.data['SBC_CONFIG_AUTH_API_URL']
+  }
+  const authConfigString = JSON.stringify(authConfig)
+  sessionStorage.setItem('AUTH_API_CONFIG', authConfigString)
+  console.log('AUTH_API_CONFIG: ' + JSON.stringify(authConfigString))
+
   const businessesUrl: string = response.data['BUSINESSES_URL']
   sessionStorage.setItem('BUSINESSES_URL', businessesUrl)
   console.log('Set Businesses URL to: ' + businessesUrl)

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -48,7 +48,7 @@ export async function fetchConfig (): Promise<any> {
   }
   const authConfigString = JSON.stringify(authConfig)
   sessionStorage.setItem('AUTH_API_CONFIG', authConfigString)
-  console.log('AUTH_API_CONFIG: ' + JSON.stringify(authConfigString))
+  console.log('AUTH_API_CONFIG: ' + authConfigString)
 
   const businessesUrl: string = response.data['BUSINESSES_URL']
   sessionStorage.setItem('BUSINESSES_URL', businessesUrl)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3764

*Description of changes:*
- added in SBC_CONFIG_AUTH_API_URL to workaround user settings call URL with double slashes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
