### PR TITLE
Fixing the doc download path issue in dev

### DIFF
--- a/src/views/IncorporationAgreement.vue
+++ b/src/views/IncorporationAgreement.vue
@@ -169,7 +169,7 @@
             <div class="download-link-container">
               <span>
                 <v-icon color="blue">mdi-file-pdf-outline</v-icon>
-                <a href="/files/benefit_company__corporation_agreement.pdf" download>
+                <a :href="documentURL" download>
                   Download the sample Incorporation Agreement and Benefit Company Articles
                 </a>
               </span>
@@ -200,6 +200,11 @@ import { AgreementType } from '@/components/IncorporationAgreement'
 export default class IncorporationAgreement extends Vue {
   private helpToggle: boolean = false
   private readMoreFlag: boolean = false
+
+  private get documentURL ():string {
+    return sessionStorage.getItem('BASE_URL') +
+    'files/benefit_company__corporation_agreement.pdf'
+  }
 }
 </script>
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3716

*Description of changes:*
The current doc path does not work in dev as the vue process path is different. So changing the doc url to leverage the base url value in session storage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
