### PR TITLE
handle consent received and consent waived states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15271,9 +15271,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.1.31.tgz",
-      "integrity": "sha512-wG5wK2iZoJaA1mIObuZfuS4bebhyD4A+nxKPjDu+tFH2pdxPkADKmuUpaDpByjLhU5De9OANXCRmD4QuFlpZZw==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.1.32.tgz",
+      "integrity": "sha512-rzoKgsDiSSllHB4TBSx8zjnV04L55AV/fGjZwFODd9zTxpcwmD5TAdff32qO4X66h7oJ2SFkm/l95G08N6+OnA==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "launchdarkly-js-client-sdk": "^2.17.0",
     "lodash": "^4.17.15",
     "regenerator-runtime": "^0.13.3",
-    "sbc-common-components": "2.1.31",
+    "sbc-common-components": "2.1.32",
     "vue": "^2.6.11",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.1.6",

--- a/src/App.vue
+++ b/src/App.vue
@@ -404,7 +404,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
   /** Set up any required fields/ validation if a Name request is present */
   private async processNameRequest (filing: any): Promise<void> {
     try {
-      let nameRequest = filing.incorporationApplication.nameRequest
+      const nameRequest = filing.incorporationApplication.nameRequest
 
       // ensure we have an NR number
       if (!nameRequest.nrNumber) {
@@ -431,7 +431,7 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
       }
       // ensure NR is consumable
       const state = this.getNrState(nrResponse)
-      if (!state || state !== NameRequestStates.APPROVED) {
+      if (state !== NameRequestStates.APPROVED && state !== NameRequestStates.CONDITIONAL) {
         this.nameRequestInvalidType = state || NameRequestStates.INVALID
         this.nameRequestInvalidErrorDialog = true
         return

--- a/src/components/AddPeopleAndRoles/OrgPerson.vue
+++ b/src/components/AddPeopleAndRoles/OrgPerson.vue
@@ -192,7 +192,7 @@ export default class OrgPerson extends Mixins(EntityFilterMixin, CommonMixin) {
   @Prop()
   private existingCompletingParty: OrgPersonIF
 
-  @Getter getCurrentDate: string
+  @Getter getCurrentDate!: string
 
   // Data Properties
   private orgPerson: OrgPersonIF = null

--- a/src/components/Summary/SummaryDefineCompany.vue
+++ b/src/components/Summary/SummaryDefineCompany.vue
@@ -68,8 +68,8 @@ import { EntityTypes } from '@/enums'
 })
 export default class SummaryDefineCompany extends Mixins(EntityFilterMixin) {
   // Getters
-  @Getter getApprovedName: GetterIF
-  @Getter isPremiumAccount: GetterIF
+  @Getter getApprovedName!: GetterIF
+  @Getter isPremiumAccount!: GetterIF
 
   // Global state
   @State(state => state.stateModel.defineCompanyStep.valid)

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -124,6 +124,9 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
     if (this.getNameRequestDetails.status === NameRequestStates.APPROVED) {
       return this.NOT_REQUIRED_STATE
     }
+    if (this.getNameRequestDetails.consentFlag === null) {
+      return this.NOT_REQUIRED_STATE
+    }
     if (this.getNameRequestDetails.consentFlag === 'R') {
       return this.RECEIVED_STATE
     }

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -17,7 +17,7 @@
             <li class="mt-4"><strong>Expiry Date:</strong> {{ formattedExpirationDate() }}</li>
             <li><strong>Status:</strong> {{ getNameRequestDetails.status }}</li>
             <li id="condition-consent" v-if="getNameRequestDetails.status === NameRequestStates.CONDITIONAL">
-              <strong>Condition/Consent:</strong> {{ conditionConsent() }}
+              <strong>Condition/Consent:</strong> {{ conditionConsent }}
             </li>
           </ul>
         </v-col>
@@ -84,6 +84,11 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
   // Template Enums
   readonly NameRequestStates = NameRequestStates
 
+  readonly RECEIVED_STATE = 'Received'
+  readonly NOT_RECEIVED_STATE = 'Not Received'
+  readonly NOT_REQUIRED_STATE = 'Not Required'
+  readonly WAIVED_STATE = 'Waived'
+
   // Global getters
   @Getter isEntityType!: GetterIF;
   @Getter isTypeBcomp!: GetterIF;
@@ -114,13 +119,18 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
     return this.toReadableDate(this.getNameRequestDetails.expirationDate)
   }
 
-  /** Return consent received string by checking if conditional and if consent has been received */
-  private conditionConsent (): string {
-    if (this.getNameRequestDetails.status === NameRequestStates.CONDITIONAL) {
-      return this.getNameRequestDetails.consentFlag === 'R' ? 'Received' : 'Not Received'
+  /** Return condition/consent string */
+  private get conditionConsent (): string {
+    if (this.getNameRequestDetails.status === NameRequestStates.APPROVED) {
+      return this.NOT_REQUIRED_STATE
     }
-
-    return ''
+    if (this.getNameRequestDetails.consentFlag === 'R') {
+      return this.RECEIVED_STATE
+    }
+    if (this.getNameRequestDetails.consentFlag === 'N') {
+      return this.WAIVED_STATE
+    }
+    return this.NOT_RECEIVED_STATE
   }
 
   /** Return formatted applicant name */

--- a/src/enums/nameRequestStates.ts
+++ b/src/enums/nameRequestStates.ts
@@ -3,7 +3,8 @@ export enum NameRequestStates {
     APPROVED = 'APPROVED',
     CANCELLED = 'CANCELLED',
     COMPLETED = 'COMPLETED',
-    CONDITIONAL = 'CONDITIONAL',
+    CONDITIONAL = 'CONDITIONAL', // NR state
+    CONDITION = 'CONDITION', // NR name state
     DRAFT = 'DRAFT',
     EXPIRED = 'EXPIRED',
     HISTORICAL = 'HISTORICAL',

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -79,9 +79,11 @@ export default class NameRequestMixin extends Mixins(DateMixin) {
     }
 
     // If the NR is awaiting consent, it is not consumable.
-    // R = received (we have consent)
-    // N = waived (we don't need consent)
-    if (nr.state === NameRequestStates.CONDITIONAL && nr.consentFlag !== 'R' && nr.consentFlag !== 'N') {
+    // null = consent not required
+    // R = consent received
+    // N = consent waived
+    if (nr.state === NameRequestStates.CONDITIONAL &&
+      nr.consentFlag !== null && nr.consentFlag !== 'R' && nr.consentFlag !== 'N') {
       return NameRequestStates.NEED_CONSENT
     }
 

--- a/tests/unit/nameRequestInfo.spec.ts
+++ b/tests/unit/nameRequestInfo.spec.ts
@@ -163,6 +163,31 @@ describe('Name Request Info component', () => {
     expect(phone.textContent).toContain('Phone: 250-356-9090')
   })
 
+  it('renders the Name Request information with consent not required', async () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    wrapper.vm.$store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
+    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = null
+
+    await Vue.nextTick()
+
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(itemCount).toEqual(6)
+    expect(wrapper.find('#condition-consent').exists()).toBe(true)
+    expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
+    expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
+    expect(requestType.textContent).toContain('Request Type: New Business')
+    expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
+    expect(status.textContent).toContain('Status: CONDITIONAL')
+    expect(conditionConsent.textContent).toContain('Condition/Consent: Not Required')
+  })
+
   it('renders the Name Request information with consent received', async () => {
     wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
     wrapper.vm.$store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
@@ -213,10 +238,10 @@ describe('Name Request Info component', () => {
     expect(conditionConsent.textContent).toContain('Condition/Consent: Waived')
   })
 
-  it('renders the Name Request information with consent not received', async () => {
+  it('renders the Name Request information with consent required', async () => {
     wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
     wrapper.vm.$store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
-    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = null
+    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = 'Y'
 
     await Vue.nextTick()
 

--- a/tests/unit/nameRequestInfo.spec.ts
+++ b/tests/unit/nameRequestInfo.spec.ts
@@ -16,6 +16,7 @@ const store = getVuexStore()
 
 describe('Name Request Info component', () => {
   let wrapper: any
+
   const mockNrData = {
     'nrNumber': 'NR 1234567',
     'entityType': 'BC',
@@ -187,6 +188,31 @@ describe('Name Request Info component', () => {
     expect(conditionConsent.textContent).toContain('Condition/Consent: Received')
   })
 
+  it('renders the Name Request information with consent waived', async () => {
+    wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
+    wrapper.vm.$store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
+    wrapper.vm.$store.state.stateModel.nameRequest.details.consentFlag = 'N'
+
+    await Vue.nextTick()
+
+    const nrListSelector = '#name-request-info ul li'
+    const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
+    const title = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
+    const entityType = wrapper.vm.$el.querySelectorAll(nrListSelector)[1]
+    const requestType = wrapper.vm.$el.querySelectorAll(nrListSelector)[2]
+    const expiryDate = wrapper.vm.$el.querySelectorAll(nrListSelector)[3]
+    const status = wrapper.vm.$el.querySelectorAll(nrListSelector)[4]
+    const conditionConsent = wrapper.vm.$el.querySelectorAll(nrListSelector)[5]
+    expect(itemCount).toEqual(6)
+    expect(wrapper.find('#condition-consent').exists()).toBe(true)
+    expect(title.textContent).toContain('NR 1234567 - MADRONA BREAD BASKET INC.')
+    expect(entityType.textContent).toContain('Entity Type: BC Benefit Company')
+    expect(requestType.textContent).toContain('Request Type: New Business')
+    expect(expiryDate.textContent).toContain('Expiry Date: Jun 24, 2020')
+    expect(status.textContent).toContain('Status: CONDITIONAL')
+    expect(conditionConsent.textContent).toContain('Condition/Consent: Waived')
+  })
+
   it('renders the Name Request information with consent not received', async () => {
     wrapper.vm.$store.state.stateModel.nameRequest = { ...mockNrData }
     wrapper.vm.$store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
@@ -254,6 +280,5 @@ describe('Name Request Info component without an NR', () => {
     expect(bulletOne.textContent).toContain('You will be filing this Incorporation Application')
     expect(bulletTwo.textContent).toContain('Your Incorporation Number will be generated at the end')
     expect(bulletThree.textContent).toContain('It is not possible to request a specific Incorporation Number')
-
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3946

*Description of changes:*
- allow conditional NR if consent is received or waived
- if approved, get name whose state is "APPROVED"
- if conditional, get name whose state is "CONDITION"
- added case for waived consent flag
- added case for null consent flag
- added unit test
- misc lint fixes
- updated sbc-common-components dependency to 2.1.32

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).