### PR TITLE
3764 account info fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -523,8 +523,13 @@ export default class App extends Mixins(DateMixin, FilingTemplateMixin, LegalApi
     if (!isSigninRoute && !isSignoutRoute) {
       this.setCurrentStep(this.$route.meta?.step)
       await this.startTokenService()
-      this.loadAccountInformation()
       await this.fetchData(true)
+
+      // Allow user settings account information to load into session storage before checking
+      // There can be a timing issue when a session is first established where account information
+      // is not available right away in session storage
+      await Vue.nextTick()
+      this.loadAccountInformation()
     }
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3764

*Description of changes:*
On the initialization of a session there can be timing issues for CURRENT_ACCOUNT local storage property as it may not be populated in the local storage fast enough. Added an await next tick to give it time to populate into local storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
