### PR TITLE
handle nameRequest object for numbered business

### DIFF
--- a/src/interfaces/filing-interfaces/filing-interface.ts
+++ b/src/interfaces/filing-interfaces/filing-interface.ts
@@ -1,6 +1,7 @@
 import { IncorporationAddressIf } from '@/interfaces/stepper-interfaces/DefineCompany/address-interface'
 import { OrgPersonIF, ShareClassIF } from '@/interfaces'
 
+/** Interface for incorporation filing data saved to the Legal API. */
 export interface IncorporationFilingIF {
   filing: {
     header: {
@@ -17,10 +18,11 @@ export interface IncorporationFilingIF {
       identifier: string
     },
     incorporationApplication: {
-      nameRequest?: {
-        nrNumber: string
+      // NB: nameRequest must match schema
+      nameRequest: {
         legalType: string
-        legalName: string
+        nrNumber?: string // only set when there is an NR
+        legalName?: string // only set when there is an NR
       },
       offices: IncorporationAddressIf | {},
       contactPoint: {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -86,15 +86,27 @@ export const getFolioNumber = (state: any): string => {
 }
 
 /**
+ * Whether this IA is for a Named Business.
+ */
+export const isNamedBusiness = (state: any): boolean => {
+  // a named business has a NR number
+  return !!state.stateModel.nameRequest.nrNumber
+}
+
+/**
+ * Returns the NR number of a name request.
+ */
+export const getNameRequestNumber = (state: any): string => {
+  return state.stateModel.nameRequest.nrNumber
+}
+
+/**
  * Returns the approved name of a name request.
  */
 export const getApprovedName = (state: any): string => {
   return state.stateModel.nameRequest.details.approvedName
 }
 
-export const getNameRequestNumber = (state: any): string => {
-  return state.stateModel.nameRequest.nrNumber
-}
 /**
  * Returns name request details.
  */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,9 +9,9 @@ import { stateModel, resourceModel } from './state'
 import {
   isRoleStaff, isAuthEdit, isAuthView, isEntityType, isPremiumAccount, isTypeBcomp, isTypeCoop,
   isShowBackBtn, isShowReviewConfirmBtn, isShowFilePayBtn, isEnableFilePayBtn, isBusySaving,
-  getFilingId, getTempId, getApprovedName, getAccountId, getFolioNumber, getNameRequestDetails, getNameRequestApplicant,
-  getOfficeAddresses, isApplicationValid, getSteps, getMaxStep, getCurrentDate, ignoreChanges,
-  haveChanges, getNameRequestNumber
+  getFilingId, getTempId, isNamedBusiness, getNameRequestNumber, getApprovedName, getAccountId,
+  getFolioNumber, getNameRequestDetails, getNameRequestApplicant, getOfficeAddresses,
+  isApplicationValid, getSteps, getMaxStep, getCurrentDate, ignoreChanges, haveChanges
 } from '@/store/getters'
 
 // Mutations
@@ -61,6 +61,8 @@ export function getVuexStore () {
       isBusySaving,
       isPremiumAccount,
       getAccountId,
+      isNamedBusiness,
+      getNameRequestNumber,
       getApprovedName,
       getTempId,
       getFilingId,
@@ -73,8 +75,7 @@ export function getVuexStore () {
       getMaxStep,
       getCurrentDate,
       ignoreChanges,
-      haveChanges,
-      getNameRequestNumber
+      haveChanges
     },
     mutations: {
       mutateAccountInformation,

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -86,9 +86,9 @@ describe('Actions component - Filing Functionality', () => {
       },
       incorporationApplication: {
         nameRequest: {
-          nrNumber: 'NR1234567',
+          nrNumber: 'NR 1234567',
           legalType: 'BC',
-          legalName: 'Test'
+          legalName: 'My Name Request Inc.'
         },
         offices: {
           registeredOffice: {
@@ -255,8 +255,8 @@ describe('Actions component - Filing Functionality', () => {
     store.state.stateModel.currentDate = '2020/01/29'
     store.state.stateModel.nameRequest = {
       entityType: 'BC',
-      nrNumber: 'NR1234567',
-      details: { approvedName: 'Test' }
+      nrNumber: 'NR 1234567',
+      details: { approvedName: 'My Name Request Inc.' }
     }
     store.state.stateModel.tombstone = {
       keycloakRoles: [],

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -46,7 +46,8 @@ const filingData = {
     },
     nameRequest: {
       legalType: 'BC',
-      nrNumber: 'NR1234567'
+      nrNumber: 'NR 1234567',
+      legalName: 'My Name Request Inc.'
     },
     offices: {
       registeredOffice: {
@@ -238,18 +239,6 @@ const nrData = {
   state: 'APPROVED'
 }
 
-const baseIaData = {
-  header: {
-    name: 'incorporationApplication',
-    filingId: 54321,
-    status: 'draft'
-  },
-  business: {
-    identifier: 'T7654321',
-    legalType: 'BC'
-  }
-}
-
 describe('Numbered company setup', () => {
   let wrapper: any
   const { assign } = window.location
@@ -289,7 +278,20 @@ describe('Numbered company setup', () => {
         data:
         {
           filing: {
-            ...baseIaData
+            header: {
+              name: 'incorporationApplication',
+              filingId: 54321,
+              status: 'draft'
+            },
+            business: {
+              identifier: 'T7654321',
+              legalType: 'BC'
+            },
+            incorporationApplication: {
+              nameRequest: {
+                legalType: 'BC'
+              }
+            }
           }
         }
       })))
@@ -325,7 +327,7 @@ describe('Numbered company setup', () => {
       .toBeDefined()
   })
 
-  it('Does not load a name request into the store', () => {
+  it('does not load a name request into the store', () => {
     // All Name request specific fields should be empty
     expect(store.state.stateModel.nameRequest.nrNumber).toEqual('')
     expect(store.state.stateModel.filingId).toBe(54321)
@@ -394,7 +396,7 @@ describe('App component', () => {
       })))
 
     // GET NR data
-    get.withArgs('nameRequests/NR1234567')
+    get.withArgs('nameRequests/NR 1234567')
       .returns(new Promise(resolve => resolve({
         data:
           {
@@ -446,9 +448,11 @@ describe('App component', () => {
   })
 
   it('loads a draft filing into the store', () => {
-    // Validate Name Request
-    expect(store.state.stateModel.entityType).toBe('BC')
+    // Validate Filing ID - set by fetchDraft()
     expect(store.state.stateModel.filingId).toBe(12345)
+
+    // Validate Entity Type
+    expect(store.state.stateModel.entityType).toBe('BC')
 
     // Validate Office Addresses
     expect(store.state.stateModel.defineCompanyStep.officeAddresses.registeredOffice)
@@ -467,6 +471,10 @@ describe('App component', () => {
     // Validate Share Structure
     expect(store.state.stateModel.createShareStructureStep.shareClasses)
       .toStrictEqual(filingData.incorporationApplication.shareClasses)
+
+    // Validate Incorporation Agreement
+    expect(store.state.stateModel.incorporationAgreementStep.agreementType)
+      .toStrictEqual(filingData.incorporationApplication.incorporationAgreement.agreementType)
   })
 
   it('loads a name request into the store', () => {
@@ -493,11 +501,9 @@ describe('App component', () => {
     expect(store.state.stateModel.nameRequest.applicant.addressLine2).toBe(nrData.applicants.addrLine2)
     expect(store.state.stateModel.nameRequest.applicant.addressLine3).toBe(nrData.applicants.addrLine3)
     expect(store.state.stateModel.nameRequest.applicant.city).toBe(nrData.applicants.city)
-    expect(store.state.stateModel.nameRequest.applicant.countryTypeCode)
-      .toBe(nrData.applicants.countryTypeCd)
+    expect(store.state.stateModel.nameRequest.applicant.countryTypeCode).toBe(nrData.applicants.countryTypeCd)
     expect(store.state.stateModel.nameRequest.applicant.postalCode).toBe(nrData.applicants.postalCd)
-    expect(store.state.stateModel.nameRequest.applicant.stateProvinceCode)
-      .toBe(nrData.applicants.stateProvinceCd)
+    expect(store.state.stateModel.nameRequest.applicant.stateProvinceCode).toBe(nrData.applicants.stateProvinceCd)
   })
 
   it('shows confirm popup if exiting before saving changes', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3962

*Description of changes:*
- in a draft, allow nameRequest object without nrNumber
- always save nameRequest object with legalType
- make nrNumber and legalName optional
- removed unneeded fallback values
- added some handy getters
- update unit tests
- misc cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).