### PR TITLE
restored redirect on app error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,9 +72,10 @@ async function start () {
 // execution and error handling
 start().catch(error => {
   console.error(error) // eslint-disable-line no-console
-  alert('There was an error starting this page.\nPlease try again later.')
+  alert('There was an error starting this page. (See console for details.)\n' +
+    'Please try again later.')
   // try to redirect to Business Registry home page
-  const businessesUrl = null // sessionStorage.getItem('BUSINESSES_URL')
+  const businessesUrl = sessionStorage.getItem('BUSINESSES_URL')
   if (businessesUrl) {
     // assume Businesses URL is always reachable
     window.location.assign(businessesUrl)


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*

I just noticed this in the code. It looks like a work-around for testing that I forgot to remove before committing. (The other UI has the same code and redirects as intended.)

In summary, the app _should_ try to redirect to the Business Registry home page on error (after alerting the user).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).