### PR TITLE
Share Structure name field should not allow numbers

### DIFF
--- a/src/components/CreateShareStructure/ShareStructure.vue
+++ b/src/components/CreateShareStructure/ShareStructure.vue
@@ -184,13 +184,13 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
 
   private excludedWordsListForClass: string [] = ['share', 'shares', 'value']
   private excludedWordsListForSeries: string [] = ['share', 'shares']
-
   // Rules
   private getNameRule (): Array<Function> {
     let rules: Array<Function> = [
       v => !!v || 'A name is required',
       v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
-      v => !/\s$/g.test(v) || 'Invalid spaces' // trailing spaces
+      v => !/\s$/g.test(v) || 'Invalid spaces', // leading spaces
+      v => /^([^0-9]*)$/g.test(v) || 'Name should not contain numbers'
     ]
     if (this.isClass) {
       rules.push(

--- a/tests/unit/ShareStructure.spec.ts
+++ b/tests/unit/ShareStructure.spec.ts
@@ -441,6 +441,7 @@ describe('Share Structure component', () => {
     expect(wrapper.vm.$data.formValid).toBe(false)
     wrapper.destroy()
   })
+
   it('Do not show error if par value < 1 does not have 0 before decimal ', async () => {
     const existingShareClass = createShareStructure(null, 1, 'Class', 'Class A', true, 100, true, 0.50, 'CAD', true)
     const shareClass = createShareStructure(null, 1, 'Class', 'Class B', true, 100, true, 0.50, 'CAD', true)
@@ -452,6 +453,19 @@ describe('Share Structure component', () => {
     expect(wrapper.find(formSelector).text())
       .not.toContain('Amounts less than 1 can be entered with up to 3 decimal place')
     expect(wrapper.vm.$data.formValid).toBe(true)
+    wrapper.destroy()
+  })
+
+  it('Do not show error if par value < 1 does not have 0 before decimal ', async () => {
+    const shareClass = createShareStructure(null, 1, 'Class', 'Class B', true, 100, true, 0.50, 'CAD', true)
+    const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, 1, null, [])
+    const inputElement: Wrapper<Vue> = wrapper.find(nameSelector)
+    inputElement.setValue('100 CLASS') // eslint-disable-line no-floating-decimal
+    inputElement.trigger('change')
+    await waitForUpdate(wrapper)
+    expect(wrapper.find(formSelector).text())
+      .toContain('Name should not contain numbers')
+    expect(wrapper.vm.$data.formValid).toBe(false)
     wrapper.destroy()
   })
 })

--- a/tests/unit/ShareStructure.spec.ts
+++ b/tests/unit/ShareStructure.spec.ts
@@ -456,7 +456,7 @@ describe('Share Structure component', () => {
     wrapper.destroy()
   })
 
-  it('Do not show error if par value < 1 does not have 0 before decimal ', async () => {
+  it('Shows error if the share structure name contains number', async () => {
     const shareClass = createShareStructure(null, 1, 'Class', 'Class B', true, 100, true, 0.50, 'CAD', true)
     const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, 1, null, [])
     const inputElement: Wrapper<Vue> = wrapper.find(nameSelector)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4054

*Description of changes:*
Added rule for not allowing numbers in the share structure name field
Added a unit test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
