### PR TITLE
4156, 4151

### DIFF
--- a/src/components/DefineCompany/BusinessContactInfo.vue
+++ b/src/components/DefineCompany/BusinessContactInfo.vue
@@ -77,16 +77,19 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Vue, Prop, Watch, Emit } from 'vue-property-decorator'
+import { Component, Vue, Prop, Watch, Emit, Mixins } from 'vue-property-decorator'
 import { mask } from 'vue-the-mask'
 
 // Interfaces
 import { BusinessContactIF } from '@/interfaces'
 
+// Mixins
+import { CommonMixin } from '@/mixins'
+
 @Component({
   directives: { mask }
 })
-export default class BusinessContactInfo extends Vue {
+export default class BusinessContactInfo extends Mixins(CommonMixin) {
   // Props
   @Prop()
   private initialValue!: BusinessContactIF
@@ -101,6 +104,15 @@ export default class BusinessContactInfo extends Vue {
   private contact: BusinessContactIF = this.initialValue
 
   private formValid: boolean = false
+
+  // Used as an initial comparison to re-validate the form
+  // This is so we don't flag errors for a new application right away
+  private defaultBusinessContact: BusinessContactIF = {
+    email: '',
+    confirmEmail: '',
+    phone: '',
+    extension: ''
+  }
 
   // Rules
   private emailRules = [
@@ -123,6 +135,8 @@ export default class BusinessContactInfo extends Vue {
   private mounted (): void {
     if (this.showErrors) {
       (this.$refs.form as Vue & { validate: () => boolean }).validate()
+    } else if (this.$refs.form && !this.isSame(this.initialValue, this.defaultBusinessContact)) {
+      (this.$refs.form as any).validate()
     }
   }
 

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -90,7 +90,7 @@
               </div>
               <div class="address-wrapper"
                    v-if="!isSame(mailingAddress, deliveryAddress, 'actions') || !inheritMailingAddress">
-                <delivery-address ref='regDeliveryAddress'
+                <delivery-address ref="regDeliveryAddress"
                   id="address-registered-delivery"
                   v-if="!inheritMailingAddress"
                   :address="deliveryAddress"

--- a/src/components/DefineCompany/OfficeAddresses.vue
+++ b/src/components/DefineCompany/OfficeAddresses.vue
@@ -63,7 +63,7 @@
             <label>Mailing Address</label>
             <div class="meta-container__inner">
               <div class="address-wrapper">
-                <mailing-address
+                <mailing-address ref="regMailingAddress"
                   id="address-registered-mailing"
                   :address="mailingAddress"
                   :editing="true"
@@ -90,7 +90,7 @@
               </div>
               <div class="address-wrapper"
                    v-if="!isSame(mailingAddress, deliveryAddress, 'actions') || !inheritMailingAddress">
-                <delivery-address
+                <delivery-address ref='regDeliveryAddress'
                   id="address-registered-delivery"
                   v-if="!inheritMailingAddress"
                   :address="deliveryAddress"
@@ -122,7 +122,7 @@
                 <label>Mailing Address</label>
                 <div class="meta-container__inner">
                   <div class="address-wrapper">
-                    <mailing-address
+                    <mailing-address ref="recMailingAddress"
                       id="address-records-mailing"
                       :address="recMailingAddress"
                       :editing="true"
@@ -149,7 +149,7 @@
                   <div
                     class="address-wrapper"
                     v-if="!isSame(recMailingAddress, recDeliveryAddress, 'actions') || !inheritRecMailingAddress">
-                    <delivery-address
+                    <delivery-address ref="recDeliveryAddress"
                       id="address-records-delivery"
                       :address="recDeliveryAddress"
                       :editing="true"
@@ -180,7 +180,7 @@ import { officeAddressSchema } from '@/schemas'
 import BaseAddress from 'sbc-common-components/src/components/BaseAddress.vue'
 
 // Interfaces
-import { IncorporationAddressIf, AddressIF, StateModelIF } from '@/interfaces'
+import { IncorporationAddressIf, AddressIF, FormType, StateModelIF } from '@/interfaces'
 
 // Enums
 import { EntityTypes } from '@/enums'
@@ -195,6 +195,13 @@ import { CommonMixin, EntityFilterMixin } from '@/mixins'
   }
 })
 export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMixin) {
+  // Refs for sbc common base address components so we can access form validation
+  $refs!: {
+    regMailingAddress: any,
+    regDeliveryAddress: any,
+    recMailingAddress: any,
+    recDeliveryAddress: any
+  }
   /**
    * Addresses object from the parent page.
    * If this is null then this is a new filing; otherwise these are the addresses from a draft/navigation
@@ -257,6 +264,36 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
     this.emitValid()
   }
 
+  private mounted (): void {
+    /**
+     * Check if addresses are the default values, if not re-validate so resumed applications show errors on start up
+     */
+
+    // Registered Mailing Address
+    if (this.$refs.regMailingAddress?.$refs?.addressForm && !this.isSame(this.mailingAddress, this.defaultAddress)) {
+      this.$refs.regMailingAddress.$refs.addressForm.validate()
+    }
+    // Registered Delivery Address
+    if (this.$refs.regDeliveryAddress?.$refs?.addressForm && !this.inheritMailingAddress &&
+        !this.isSame(this.deliveryAddress, this.defaultAddress)) {
+      this.$refs.regDeliveryAddress.$refs.addressForm.validate()
+    }
+    // If records address is not inherited - check if we need to re-validate these
+    if (!this.inheritRegisteredAddress) {
+      // Records Mailing Address
+      if (this.$refs.recMailingAddress?.$refs?.addressForm &&
+        !this.isSame(this.recMailingAddress, this.defaultAddress)) {
+        this.$refs.recMailingAddress.$refs.addressForm.validate()
+      }
+
+      // Records Delivery Address
+      if (this.$refs.recMailingAddress?.$refs?.addressForm && !this.inheritRecMailingAddress &&
+          !this.isSame(this.recDeliveryAddress, this.defaultAddress)) {
+        this.$refs.recDeliveryAddress.$refs.addressForm.validate()
+      }
+    }
+  }
+
   /**
    * Sets address data.
    * @param loadInheritedFlags used to update inherited flags based on isSame checks if true
@@ -302,12 +339,13 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
   //
   /** Whether the address form is valid. */
   private get formValid (): boolean {
-    return (
-      this.deliveryAddressValid &&
-      (this.inheritMailingAddress || this.mailingAddressValid) &&
-      this.recDeliveryAddressValid &&
-      (this.inheritRecMailingAddress || this.recMailingAddressValid)
-    )
+    const registeredOfficeValid = this.mailingAddressValid &&
+      (this.deliveryAddressValid || this.inheritMailingAddress)
+
+    const recordsOfficeValid = this.inheritRegisteredAddress ||
+      (this.recMailingAddressValid && (this.inheritRecMailingAddress || this.recDeliveryAddressValid))
+
+    return registeredOfficeValid && recordsOfficeValid
   }
 
   /** Whether the address object is empty. */

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -354,6 +354,136 @@ describe('same as checkboxes reset addresses to default when unchecked - BCOMP',
   })
 })
 
+describe('should properly emit valid - BCOMP', () => {
+  let wrapper: any
+  const localVue = createLocalVue()
+  const invalidDeliveryAddress = {
+    addressCity: 'someCity',
+    addressCountry: 'someCountry',
+    addressRegion: 'someRegion',
+    postalCode: 'somePostalCode',
+    streetAddress: 'someStreet'
+  }
+
+  const invalidMailingAddress = {
+    addressCity: 'someCity',
+    addressCountry: 'someCountry',
+    addressRegion: 'someRegion',
+    postalCode: 'somePostalCode',
+    streetAddress: 'someStreet'
+  }
+
+  const validDeliveryAddress = {
+    addressCity: 'someCity1',
+    addressCountry: 'CA',
+    addressRegion: 'BC',
+    postalCode: 'somePostalCode',
+    streetAddress: 'someStreet'
+  }
+
+  const validMailingAddress = {
+    addressCity: 'someCity2',
+    addressCountry: 'CA',
+    addressRegion: 'BC',
+    postalCode: 'somePostalCode',
+    streetAddress: 'someStreet'
+  }
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  beforeAll(() => {
+    // init store
+    store.state.stateModel.entityType = 'BC'
+  })
+
+  it('should emit valid form', async () => {
+    wrapper = mount(OfficeAddresses, {
+      propsData: {
+        inputAddresses: {
+          registeredOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress },
+          recordsOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress } },
+        isEditing: true
+      },
+      localVue,
+      store,
+      vuetify
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('valid').pop()).toEqual([true])
+  })
+
+  it('should emit invalid with invalid registered delivery address', async () => {
+    wrapper = mount(OfficeAddresses, {
+      propsData: {
+        inputAddresses: {
+          registeredOffice: { deliveryAddress: invalidDeliveryAddress, mailingAddress: validMailingAddress },
+          recordsOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress } },
+        isEditing: true
+      },
+      localVue,
+      store,
+      vuetify
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('valid').pop()).toEqual([false])
+  })
+
+  it('should emit invalid with invalid registered mailing address', async () => {
+    wrapper = mount(OfficeAddresses, {
+      propsData: {
+        inputAddresses: {
+          registeredOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: invalidMailingAddress },
+          recordsOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress } },
+        isEditing: true
+      },
+      localVue,
+      store,
+      vuetify
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('valid').pop()).toEqual([false])
+  })
+
+  it('should emit invalid with invalid records delivery address', async () => {
+    wrapper = mount(OfficeAddresses, {
+      propsData: {
+        inputAddresses: {
+          registeredOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress },
+          recordsOffice: { deliveryAddress: invalidDeliveryAddress, mailingAddress: validMailingAddress } },
+        isEditing: true
+      },
+      localVue,
+      store,
+      vuetify
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('valid').pop()).toEqual([false])
+  })
+
+  it('should emit invalid with invalid records mailing address', async () => {
+    wrapper = mount(OfficeAddresses, {
+      propsData: {
+        inputAddresses: {
+          registeredOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: validMailingAddress },
+          recordsOffice: { deliveryAddress: validDeliveryAddress, mailingAddress: invalidMailingAddress } },
+        isEditing: true
+      },
+      localVue,
+      store,
+      vuetify
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.emitted('valid').pop()).toEqual([false])
+  })
+})
+
 describe('Office Addresses component - Summary UI', () => {
   let wrapper: any
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4156, /bcgov/entity#4151

*Description of changes:*
Fixes and updates to step 1 so form validation errors show when a user resumes an application

*Office Addresses*
- added references to address components (sbc common component BaseAddress) so the form validate() function is accessible
- add checks on mounted to compare the default address state to what is loaded so re-validation can occur to show errors (e.g. non BC province)
- updated formValid() check to fix a bug where the validity for all addresses were not correct

*Business Contact*
- Added a default business contact object for comparison to re-evaluate validation (e.g. invalid email)
- Added check on mount to re-validate form if it is not the same as the default form state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
