### PR TITLE
updated browsers list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4918,9 +4918,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001115",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001115.tgz",
-      "integrity": "sha512-NZrG0439ePYna44lJX8evHX2L7Z3/z3qjVLnHgbBb/duNEnGo348u+BQS5o4HTWcrb++100dHFrU36IesIrC1Q=="
+      "version": "1.0.30001194",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
+      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
- when npm prompts us (periodically), we need to run `npx browserslist@latest --update-db`
- this updates the package lock file, which is what I'm committing here

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).